### PR TITLE
Fix "Depth cannot be negative" for FTX orderbook calls

### DIFF
--- a/CryptoBotCore/API/FtxAPI.cs
+++ b/CryptoBotCore/API/FtxAPI.cs
@@ -45,7 +45,9 @@ namespace CryptoBotCore.API
 
         private async Task<decimal> getCurrentPrice()
         {
-            var callResult = await client.GetOrderBookAsync($"{pair_base}/{pair_quote}", 0);
+            var callResult = await client.GetOrderBookAsync($"{pair_base}/{pair_quote}", 20); 
+            // depth of the orderbook arbitrarly set to 20 (default value according to the official FTX api doc)
+            // depth can't be set to 0 or we get an error 400 with the answer "Depth cannot be negative"
             // Make sure to check if the call was successful
             if (!callResult.Success)
             {


### PR DESCRIPTION
Hello,

Just out of nowhere this kind of error is popping.  
![image](https://user-images.githubusercontent.com/7483201/149019689-b1d2aff5-b94d-4c79-a03c-46996e54fdaa.png)   
  
The root of this error probably lies in some changes on the FTX exchange API as they released a new one for Future recently apparently (~8 days ago) they may have slightly changed other things.    

The [library we use](https://www.nuget.org/packages/FTX.Net/0.1.9) doesn't fallback on null or zero values or enforce any checks so we're directly getting an answer from the FTX api server.  
https://github.com/JKorf/FTX.Net/blob/e1937557c8c7935117e09cd6a274d39ef45c3e9d/FTX.Net/FTXClient.cs#L186  
So... indeed the error we get doesn't make sense when we pass a "0" value but let's not make a fuss about all of this and just pass the default value of 20 for the orderbook depth.  
