### PR TITLE
Update .gitignore for monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,49 @@ MigrationBackup/
 
 # Visual Studio Code working folder
 .vscode/
+
+# ======================================
+# Android (Kotlin/Gradle)
+# ======================================
+*.apk
+*.aab
+*.ap_
+*.dex
+local.properties
+build/
+.gradle/
+.kotlin/
+captures/
+.externalNativeBuild/
+.cxx/
+
+# ======================================
+# IntelliJ IDEA / Android Studio
+# ======================================
+.idea/
+*.iml
+
+# ======================================
+# Expo / React Native
+# ======================================
+.expo/
+dist/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# ======================================
+# Claude Code session data
+# ======================================
+.claude/
+
+# ======================================
+# Telegram converter output (large files)
+# ======================================
+telegram-accbot-converter/result*.json
+telegram-accbot-converter/output/
+
+# ======================================
+# Miscellaneous
+# ======================================
+nul


### PR DESCRIPTION
## Summary
- Add ignore patterns for Android/Gradle build artifacts, IntelliJ IDEA/Android Studio, Expo/React Native, Claude Code session data, and telegram converter output
- Prevents ~200+ MB of build artifacts and caches from being accidentally committed

## Test plan
- [x] Verified `.claude/`, `nul`, `build/`, `.gradle/`, `.idea/`, `local.properties`, `node_modules/`, `.expo/` no longer appear in `git status`
- [x] Verified `docs/`, `AccBotWizard/` source, `accbot-android/` source still show as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)