### PR TITLE
Prepare for Play Store release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -23,29 +23,55 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x accbot-android/gradlew
 
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > accbot-android/accbot-upload.jks
+
       - name: Build Debug APK
         run: |
           cd accbot-android
           ./gradlew assembleDebug
 
-      - name: Build Release APK
+      - name: Build signed Release APK
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/accbot-android/accbot-upload.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           cd accbot-android
           ./gradlew assembleRelease
+
+      - name: Build signed AAB (for Play Store)
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/accbot-android/accbot-upload.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          cd accbot-android
+          ./gradlew bundleRelease
 
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Rename APKs with version
+      - name: Rename artifacts with version
         run: |
-          cd accbot-android/app/build/outputs/apk
-          if [ -f debug/app-debug.apk ]; then
-            mv debug/app-debug.apk debug/accbot-${{ steps.version.outputs.VERSION }}-debug.apk
+          cd accbot-android/app/build/outputs
+          if [ -f apk/debug/app-debug.apk ]; then
+            mv apk/debug/app-debug.apk apk/debug/accbot-${{ steps.version.outputs.VERSION }}-debug.apk
           fi
-          if [ -f release/app-release-unsigned.apk ]; then
-            mv release/app-release-unsigned.apk release/accbot-${{ steps.version.outputs.VERSION }}-release.apk
+          if [ -f apk/release/app-release.apk ]; then
+            mv apk/release/app-release.apk apk/release/accbot-${{ steps.version.outputs.VERSION }}-release.apk
           fi
+          if [ -f bundle/release/app-release.aab ]; then
+            mv bundle/release/app-release.aab bundle/release/accbot-${{ steps.version.outputs.VERSION }}-release.aab
+          fi
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -f accbot-android/accbot-upload.jks
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -54,24 +80,24 @@ jobs:
           body: |
             ## AccBot Android v${{ steps.version.outputs.VERSION }}
 
-            Self-custody Bitcoin DCA app for Android.
+            Self-custody crypto DCA app for Android.
 
-            ### Installation
-            1. Download the APK file below
-            2. Enable "Install from unknown sources" in Android settings
-            3. Open the APK file to install
+            ### Downloads
+            - **APK** — install directly on your device (enable "Install from unknown sources")
+            - **AAB** — upload to Google Play Console
 
             ### What's New
             See the [commit history](https://github.com/${{ github.repository }}/commits/v${{ steps.version.outputs.VERSION }}) for changes.
           files: |
             accbot-android/app/build/outputs/apk/debug/accbot-${{ steps.version.outputs.VERSION }}-debug.apk
             accbot-android/app/build/outputs/apk/release/accbot-${{ steps.version.outputs.VERSION }}-release.apk
+            accbot-android/app/build/outputs/bundle/release/accbot-${{ steps.version.outputs.VERSION }}-release.aab
           draft: false
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Optional: Build and test on PRs
+  # Build and test on PRs
   test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/accbot-android/app/build.gradle.kts
+++ b/accbot-android/app/build.gradle.kts
@@ -18,6 +18,18 @@ android {
     namespace = "com.accbot.dca"
     compileSdk = 36
 
+    signingConfigs {
+        create("release") {
+            val keystorePath = System.getenv("KEYSTORE_PATH")
+            if (keystorePath != null) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
+                keyAlias = System.getenv("KEY_ALIAS") ?: "accbot-upload"
+                keyPassword = System.getenv("KEY_PASSWORD") ?: ""
+            }
+        }
+    }
+
     defaultConfig {
         applicationId = "com.accbot.dca"
         minSdk = 26
@@ -40,6 +52,7 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+            signingConfig = signingConfigs.findByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/accbot-android/store-assets/README.md
+++ b/accbot-android/store-assets/README.md
@@ -1,0 +1,47 @@
+# AccBot Store Assets
+
+Play Store graphics for AccBot DCA.
+
+## Files
+
+| File | Purpose | Dimensions |
+|---|---|---|
+| `icon-512.svg` | Hi-res app icon | 512 x 512 |
+| `feature-graphic-1024x500.svg` | Feature graphic banner | 1024 x 500 |
+
+## Convert SVG to PNG
+
+### Option 1: Browser
+1. Open the SVG file in Chrome/Edge
+2. Right-click → Inspect → Console
+3. Take a screenshot at the correct resolution
+
+### Option 2: Inkscape (CLI)
+```bash
+inkscape icon-512.svg --export-type=png --export-width=512 --export-height=512 -o icon-512.png
+inkscape feature-graphic-1024x500.svg --export-type=png --export-width=1024 --export-height=500 -o feature-graphic-1024x500.png
+```
+
+### Option 3: Online
+Upload SVGs to [svgtopng.com](https://svgtopng.com) or [cloudconvert.com](https://cloudconvert.com).
+
+## Screenshots
+
+Screenshots must be captured from the running app. Recommended set (minimum 2, ideal 8):
+
+1. Dashboard with active plan and portfolio summary
+2. Portfolio performance chart with ROI
+3. Strategy selection (Classic, ATH, Fear & Greed)
+4. Transaction history with filters
+5. Exchange setup with QR scanning
+6. Security onboarding screen
+7. Sandbox mode demonstration
+8. Settings with exchange management
+
+**Dimensions:** 1080 x 1920 (portrait) or 1920 x 1080 (landscape)
+
+### Capture via ADB
+```bash
+adb shell screencap -p /sdcard/screenshot.png
+adb pull /sdcard/screenshot.png ./screenshots/
+```

--- a/accbot-android/store-assets/feature-graphic-1024x500.svg
+++ b/accbot-android/store-assets/feature-graphic-1024x500.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="500" viewBox="0 0 1024 500">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0E0E1A"/>
+      <stop offset="100%" stop-color="#16213E"/>
+    </linearGradient>
+    <radialGradient id="accent-glow" cx="30%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4ECCA3" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#0E0E1A" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1024" height="500" fill="url(#bg)"/>
+  <rect width="1024" height="500" fill="url(#accent-glow)"/>
+
+  <!-- Decorative grid dots -->
+  <g opacity="0.08" fill="#4ECCA3">
+    <circle cx="50" cy="50" r="2"/><circle cx="100" cy="50" r="2"/><circle cx="150" cy="50" r="2"/>
+    <circle cx="200" cy="50" r="2"/><circle cx="250" cy="50" r="2"/><circle cx="300" cy="50" r="2"/>
+    <circle cx="50" cy="100" r="2"/><circle cx="100" cy="100" r="2"/><circle cx="150" cy="100" r="2"/>
+    <circle cx="200" cy="100" r="2"/><circle cx="250" cy="100" r="2"/><circle cx="300" cy="100" r="2"/>
+    <circle cx="50" cy="150" r="2"/><circle cx="100" cy="150" r="2"/><circle cx="150" cy="150" r="2"/>
+    <circle cx="200" cy="150" r="2"/><circle cx="250" cy="150" r="2"/><circle cx="300" cy="150" r="2"/>
+  </g>
+
+  <!-- Left side: App name and tagline -->
+  <g transform="translate(80, 140)">
+    <!-- App name -->
+    <text font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF">
+      AccBot
+    </text>
+    <text font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="bold" fill="#4ECCA3" x="280">
+      DCA
+    </text>
+
+    <!-- Tagline -->
+    <text y="60" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#A0A0A0">
+      Stack crypto on autopilot
+    </text>
+
+    <!-- Feature pills -->
+    <g transform="translate(0, 110)">
+      <rect x="0" y="0" width="140" height="36" rx="18" fill="#4ECCA3" fill-opacity="0.15" stroke="#4ECCA3" stroke-width="1.5"/>
+      <text x="70" y="24" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#4ECCA3">Self-Custody</text>
+
+      <rect x="155" y="0" width="140" height="36" rx="18" fill="#4ECCA3" fill-opacity="0.15" stroke="#4ECCA3" stroke-width="1.5"/>
+      <text x="225" y="24" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#4ECCA3">7 Exchanges</text>
+
+      <rect x="310" y="0" width="150" height="36" rx="18" fill="#4ECCA3" fill-opacity="0.15" stroke="#4ECCA3" stroke-width="1.5"/>
+      <text x="385" y="24" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#4ECCA3">Open Source</text>
+    </g>
+  </g>
+
+  <!-- Right side: Stylized phone mockup -->
+  <g transform="translate(650, 40)">
+    <!-- Phone frame -->
+    <rect x="0" y="0" width="240" height="420" rx="24" fill="#1A1A2E" stroke="#333" stroke-width="2"/>
+
+    <!-- Screen area -->
+    <rect x="10" y="40" width="220" height="340" rx="4" fill="#0E0E1A"/>
+
+    <!-- Notch -->
+    <rect x="80" y="8" width="80" height="24" rx="12" fill="#0E0E1A"/>
+
+    <!-- Screen content: mini chart -->
+    <g transform="translate(25, 65)">
+      <text font-family="Arial, Helvetica, sans-serif" font-size="12" fill="#A0A0A0">Portfolio</text>
+      <text y="28" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="bold" fill="#FFFFFF">0.0847 BTC</text>
+      <text y="48" font-family="Arial, Helvetica, sans-serif" font-size="13" fill="#4ECCA3">+12.4%</text>
+
+      <!-- Mini chart area -->
+      <polyline points="0,130 20,125 40,120 60,115 80,108 100,100 120,88 140,82 160,70 180,55"
+                fill="none" stroke="#4ECCA3" stroke-width="2.5" stroke-linecap="round"/>
+      <!-- Chart fill -->
+      <polygon points="0,130 20,125 40,120 60,115 80,108 100,100 120,88 140,82 160,70 180,55 180,140 0,140"
+               fill="#4ECCA3" fill-opacity="0.1"/>
+
+      <!-- Bars below chart -->
+      <g transform="translate(0, 170)">
+        <rect x="0" y="35" width="18" height="25" rx="3" fill="#4ECCA3" opacity="0.4"/>
+        <rect x="22" y="25" width="18" height="35" rx="3" fill="#4ECCA3" opacity="0.5"/>
+        <rect x="44" y="20" width="18" height="40" rx="3" fill="#4ECCA3" opacity="0.6"/>
+        <rect x="66" y="15" width="18" height="45" rx="3" fill="#4ECCA3" opacity="0.7"/>
+        <rect x="88" y="8" width="18" height="52" rx="3" fill="#4ECCA3" opacity="0.8"/>
+        <rect x="110" y="0" width="18" height="60" rx="3" fill="#4ECCA3"/>
+      </g>
+    </g>
+
+    <!-- Home bar -->
+    <rect x="85" y="398" width="70" height="5" rx="2.5" fill="#666"/>
+  </g>
+
+  <!-- Bottom accent line -->
+  <rect x="0" y="494" width="1024" height="6" fill="#4ECCA3" opacity="0.6"/>
+</svg>

--- a/accbot-android/store-assets/icon-512.svg
+++ b/accbot-android/store-assets/icon-512.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <!-- Background -->
+  <rect width="512" height="512" rx="100" fill="#16213E"/>
+
+  <!-- Subtle gradient overlay -->
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#4ECCA3" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#16213E" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" rx="100" fill="url(#glow)"/>
+
+  <!-- Main circle -->
+  <circle cx="256" cy="256" r="170" fill="none" stroke="#4ECCA3" stroke-width="8" opacity="0.3"/>
+  <circle cx="256" cy="256" r="140" fill="#4ECCA3" fill-opacity="0.1" stroke="#4ECCA3" stroke-width="4"/>
+
+  <!-- Accumulation/stacking bars (like a rising chart) -->
+  <g transform="translate(256,256)">
+    <!-- Bar chart representing DCA accumulation -->
+    <rect x="-80" y="20" width="30" height="60" rx="4" fill="#4ECCA3" opacity="0.5"/>
+    <rect x="-40" y="-10" width="30" height="90" rx="4" fill="#4ECCA3" opacity="0.65"/>
+    <rect x="0" y="-45" width="30" height="125" rx="4" fill="#4ECCA3" opacity="0.8"/>
+    <rect x="40" y="-85" width="30" height="165" rx="4" fill="#4ECCA3"/>
+
+    <!-- Upward trend line -->
+    <polyline points="-65,-5 -25,-35 15,-70 55,-110"
+              fill="none" stroke="#FFFFFF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Arrow tip -->
+    <polygon points="55,-110 45,-100 50,-115" fill="#FFFFFF"/>
+  </g>
+
+  <!-- "A" letter stylized -->
+  <text x="256" y="210" text-anchor="middle" font-family="Arial, Helvetica, sans-serif"
+        font-size="80" font-weight="bold" fill="#FFFFFF" letter-spacing="-2">A</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add release `signingConfigs` to `build.gradle.kts` (env-based, no-op when env vars absent)
- Update CI workflow to build signed APK + AAB and attach to GitHub Releases
- Add store asset SVGs (512x512 icon, 1024x500 feature graphic) with conversion guide
- Add `.nojekyll` for GitHub Pages to skip Jekyll processing

## Test plan
- [ ] Local `assembleDebug` still works without env vars
- [ ] CI workflow syntax is valid (check Actions tab after merge)
- [ ] SVG files render correctly in browser
- [ ] GitHub Pages serves privacy policy at https://crynners.github.io/AccBot/privacy.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)