### PR TITLE
Android v2.0.111: fix Coinmate min order, QR scanner, CSV import

### DIFF
--- a/accbot-android/app/build.gradle.kts
+++ b/accbot-android/app/build.gradle.kts
@@ -126,11 +126,15 @@ dependencies {
     // Vico - Compose charting library for portfolio performance
     implementation("com.patrykandpatrick.vico:compose-m3:2.4.3")
 
-    // QR Code scanning with ML Kit and CameraX
+    // QR Code scanning and OCR with ML Kit and CameraX
     implementation("com.google.mlkit:barcode-scanning:17.3.0")
+    implementation("com.google.mlkit:text-recognition:16.0.1")
     implementation("androidx.camera:camera-camera2:1.5.1")
     implementation("androidx.camera:camera-lifecycle:1.5.1")
     implementation("androidx.camera:camera-view:1.5.1")
+
+    // CRON expression parsing for custom DCA schedules
+    implementation("com.cronutils:cron-utils:9.2.1")
 
     // Testing
     testImplementation("junit:junit:4.13.2")

--- a/accbot-android/app/proguard-rules.pro
+++ b/accbot-android/app/proguard-rules.pro
@@ -36,3 +36,7 @@
 
 # Vico charting library
 -keep class com.patrykandpatrick.vico.** { *; }
+
+# cron-utils
+-keep class com.cronutils.** { *; }
+-dontwarn com.cronutils.**

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/Daos.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/Daos.kt
@@ -175,6 +175,9 @@ interface TransactionDao {
     @Query("SELECT exchangeOrderId FROM transactions WHERE planId = :planId AND exchangeOrderId IS NOT NULL")
     suspend fun getExchangeOrderIdsByPlan(planId: Long): List<String>
 
+    @Query("SELECT MAX(executedAt) FROM transactions WHERE planId = :planId AND status = 'COMPLETED'")
+    suspend fun getLatestTransactionTimestamp(planId: Long): Long?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTransaction(transaction: TransactionEntity): Long
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/DcaDatabase.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/DcaDatabase.kt
@@ -17,7 +17,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         MonthlySummaryEntity::class,
         DailyPriceEntity::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -136,6 +136,13 @@ abstract class DcaDatabase : RoomDatabase() {
             }
         }
 
+        // Migration from version 7 to 8: Add cronExpression column to dca_plans
+        private val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE dca_plans ADD COLUMN cronExpression TEXT DEFAULT NULL")
+            }
+        }
+
         /**
          * Get the database instance for the specified mode.
          * Production and sandbox use separate database files to prevent data mixing.
@@ -192,7 +199,7 @@ abstract class DcaDatabase : RoomDatabase() {
                 DcaDatabase::class.java,
                 databaseName
             )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
                 // Only allow destructive migration on app downgrade, never on failed upgrade
                 // This protects user's transaction history from accidental deletion
                 .fallbackToDestructiveMigrationOnDowngrade()

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/Entities.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/Entities.kt
@@ -120,6 +120,7 @@ data class DcaPlanEntity(
     val fiat: String,
     val amount: BigDecimal,
     val frequency: DcaFrequency,
+    val cronExpression: String? = null,
     val strategy: DcaStrategy = DcaStrategy.Classic,
     val isEnabled: Boolean = true,
     val withdrawalEnabled: Boolean = false,

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/ImportTradeHistoryUseCase.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/ImportTradeHistoryUseCase.kt
@@ -1,0 +1,111 @@
+package com.accbot.dca.domain.usecase
+
+import com.accbot.dca.data.local.TransactionDao
+import com.accbot.dca.data.local.TransactionEntity
+import com.accbot.dca.domain.model.Exchange
+import com.accbot.dca.domain.model.TransactionStatus
+import com.accbot.dca.exchange.ExchangeApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.math.BigDecimal
+import java.time.Instant
+import javax.inject.Inject
+
+sealed class ApiImportProgress {
+    data class Fetching(val page: Int, val totalFetched: Int) : ApiImportProgress()
+    data class Deduplicating(val count: Int) : ApiImportProgress()
+    data class Importing(val newCount: Int) : ApiImportProgress()
+    data class Complete(val imported: Int, val skipped: Int) : ApiImportProgress()
+    data class Error(val message: String) : ApiImportProgress()
+}
+
+class ImportTradeHistoryUseCase @Inject constructor(
+    private val transactionDao: TransactionDao
+) {
+    fun importFromApi(
+        api: ExchangeApi,
+        planId: Long,
+        crypto: String,
+        fiat: String,
+        exchange: Exchange
+    ): Flow<ApiImportProgress> = flow {
+        try {
+            // Get the latest transaction timestamp for incremental import
+            val latestTimestamp = transactionDao.getLatestTransactionTimestamp(planId)
+            val sinceInstant = latestTimestamp?.let { Instant.ofEpochMilli(it) }
+
+            // Fetch all pages
+            val allTrades = mutableListOf<com.accbot.dca.domain.model.HistoricalTrade>()
+            var cursor = sinceInstant
+            var page = 0
+            val maxPages = 50
+
+            do {
+                page++
+                emit(ApiImportProgress.Fetching(page, allTrades.size))
+
+                val result = api.getTradeHistory(
+                    crypto = crypto,
+                    fiat = fiat,
+                    sinceTimestamp = cursor,
+                    limit = 100
+                )
+
+                // Filter to BUY trades only
+                val buyTrades = result.trades.filter { it.side == "BUY" }
+                allTrades.addAll(buyTrades)
+
+                // Update cursor to the latest trade timestamp for next page
+                if (result.trades.isNotEmpty()) {
+                    cursor = result.trades.maxOf { it.timestamp }
+                }
+
+                if (!result.hasMore || page >= maxPages) break
+            } while (true)
+
+            if (allTrades.isEmpty()) {
+                emit(ApiImportProgress.Complete(imported = 0, skipped = 0))
+                return@flow
+            }
+
+            // Dedup via existing exchangeOrderIds
+            emit(ApiImportProgress.Deduplicating(allTrades.size))
+            val existingOrderIds = transactionDao.getExchangeOrderIdsByPlan(planId).toSet()
+            val newTrades = allTrades.filter { it.orderId !in existingOrderIds }
+
+            if (newTrades.isEmpty()) {
+                emit(ApiImportProgress.Complete(imported = 0, skipped = allTrades.size))
+                return@flow
+            }
+
+            emit(ApiImportProgress.Importing(newTrades.size))
+
+            // Map to TransactionEntity and batch insert
+            val entities = newTrades.map { trade ->
+                TransactionEntity(
+                    planId = planId,
+                    exchange = exchange,
+                    crypto = trade.crypto,
+                    fiat = trade.fiat,
+                    fiatAmount = trade.fiatAmount,
+                    cryptoAmount = trade.cryptoAmount,
+                    price = trade.price,
+                    fee = trade.fee,
+                    feeAsset = trade.feeAsset,
+                    status = TransactionStatus.COMPLETED,
+                    exchangeOrderId = trade.orderId,
+                    executedAt = trade.timestamp
+                )
+            }
+
+            transactionDao.insertTransactions(entities)
+
+            emit(ApiImportProgress.Complete(
+                imported = newTrades.size,
+                skipped = allTrades.size - newTrades.size
+            ))
+        } catch (e: Exception) {
+            emit(ApiImportProgress.Error(e.message ?: "Import failed"))
+        }
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/util/CronUtils.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/util/CronUtils.kt
@@ -1,0 +1,105 @@
+package com.accbot.dca.domain.util
+
+import android.util.Log
+import com.cronutils.model.Cron
+import com.cronutils.model.CronType
+import com.cronutils.model.definition.CronDefinitionBuilder
+import com.cronutils.model.time.ExecutionTime
+import com.cronutils.parser.CronParser
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Utility wrapper around cron-utils for CRON expression parsing,
+ * validation, description, and next-execution calculation.
+ */
+object CronUtils {
+    private const val TAG = "CronUtils"
+
+    private val cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX)
+    private val parser = CronParser(cronDefinition)
+
+    /**
+     * Parse a CRON expression. Returns null if invalid.
+     */
+    private fun parse(expression: String): Cron? {
+        return try {
+            parser.parse(expression).validate()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Check if a CRON expression is valid (5-field UNIX CRON).
+     */
+    fun isValidCron(expression: String): Boolean {
+        return parse(expression) != null
+    }
+
+    /**
+     * Generate a human-readable description of a CRON expression.
+     * Returns null if the expression is invalid.
+     */
+    fun describeCron(expression: String): String? {
+        val cron = parse(expression) ?: return null
+        return try {
+            // Use cron-utils descriptor
+            val descriptor = com.cronutils.descriptor.CronDescriptor.instance(java.util.Locale.ENGLISH)
+            descriptor.describe(cron)
+        } catch (e: Exception) {
+            Log.w(TAG, "CronDescriptor failed for '$expression', using fallback", e)
+            // Fallback: just show the expression itself
+            expression
+        }
+    }
+
+    /**
+     * Calculate the next execution time after the given instant.
+     * Returns null if the expression is invalid.
+     */
+    fun getNextExecution(expression: String, after: Instant): Instant? {
+        val cron = parse(expression) ?: return null
+        return try {
+            val executionTime = ExecutionTime.forCron(cron)
+            val zdt = ZonedDateTime.ofInstant(after, ZoneId.systemDefault())
+            executionTime.nextExecution(zdt)
+                .orElse(null)
+                ?.toInstant()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to calculate next execution for '$expression'", e)
+            null
+        }
+    }
+
+    /**
+     * Estimate the average interval in minutes for a CRON expression.
+     * Used for monthly cost estimates. Returns null if invalid.
+     */
+    fun getIntervalMinutesEstimate(expression: String): Long? {
+        val cron = parse(expression) ?: return null
+        return try {
+            val executionTime = ExecutionTime.forCron(cron)
+            val now = ZonedDateTime.now()
+
+            // Calculate next 5 executions and average the intervals
+            val executions = mutableListOf<ZonedDateTime>()
+            var current = now
+            repeat(6) {
+                val next = executionTime.nextExecution(current).orElse(null) ?: return@repeat
+                executions.add(next)
+                current = next
+            }
+
+            if (executions.size < 2) return 1440L // Default to daily
+
+            val totalMinutes = java.time.Duration.between(executions.first(), executions.last()).toMinutes()
+            val intervals = executions.size - 1
+            maxOf(totalMinutes / intervals, 1L)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to estimate interval for '$expression'", e)
+            1440L // Default to daily
+        }
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/util/ScheduleBuilderState.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/util/ScheduleBuilderState.kt
@@ -1,0 +1,170 @@
+package com.accbot.dca.domain.util
+
+/**
+ * Schedule type for the visual schedule builder.
+ */
+enum class ScheduleType {
+    DAILY,
+    DAYS_OF_WEEK,
+    DAYS_OF_MONTH
+}
+
+/**
+ * Represents a time-of-day with hour and minute.
+ */
+data class TimeOfDay(val hour: Int, val minute: Int) : Comparable<TimeOfDay> {
+    override fun compareTo(other: TimeOfDay): Int {
+        val hourCmp = hour.compareTo(other.hour)
+        return if (hourCmp != 0) hourCmp else minute.compareTo(other.minute)
+    }
+
+    fun format(): String = "%d:%02d".format(hour, minute)
+}
+
+/**
+ * Pure state model for the visual schedule builder.
+ * Maps bidirectionally to/from 5-field UNIX CRON expressions.
+ *
+ * Design: single-minute model — minute selector is shared across all selected hours.
+ * Hours are multi-selectable. This maps cleanly to CRON fields.
+ */
+data class ScheduleBuilderState(
+    val scheduleType: ScheduleType = ScheduleType.DAILY,
+    val selectedMinute: Int = 0,
+    val selectedHours: Set<Int> = setOf(9),
+    val selectedDaysOfWeek: Set<Int> = emptySet(),  // 0=Sun, 1=Mon..6=Sat (CRON convention)
+    val selectedDaysOfMonth: Set<Int> = emptySet(),  // 1-31
+    val useAdvancedMode: Boolean = false,
+    val rawCronExpression: String = ""
+) {
+    /**
+     * Generate a 5-field UNIX CRON expression from the visual state.
+     * Returns null if the state is incomplete.
+     */
+    fun toCronExpression(): String? {
+        if (useAdvancedMode) {
+            return rawCronExpression.ifBlank { null }
+        }
+
+        if (selectedHours.isEmpty()) return null
+
+        val minuteField = selectedMinute.toString()
+        val hourField = selectedHours.sorted().joinToString(",")
+
+        return when (scheduleType) {
+            ScheduleType.DAILY -> "$minuteField $hourField * * *"
+            ScheduleType.DAYS_OF_WEEK -> {
+                if (selectedDaysOfWeek.isEmpty()) return null
+                val dowField = selectedDaysOfWeek.sorted().joinToString(",")
+                "$minuteField $hourField * * $dowField"
+            }
+            ScheduleType.DAYS_OF_MONTH -> {
+                if (selectedDaysOfMonth.isEmpty()) return null
+                val domField = selectedDaysOfMonth.sorted().joinToString(",")
+                "$minuteField $hourField $domField * *"
+            }
+        }
+    }
+
+    /**
+     * Whether the current state produces a valid CRON expression.
+     */
+    val isValid: Boolean
+        get() {
+            val cron = toCronExpression() ?: return false
+            return CronUtils.isValidCron(cron)
+        }
+
+    /**
+     * The list of formatted times based on selected hours and minute.
+     */
+    val selectedTimes: List<TimeOfDay>
+        get() = selectedHours.map { TimeOfDay(it, selectedMinute) }.sorted()
+
+    companion object {
+        /**
+         * Parse a CRON expression back into visual builder state.
+         * Falls back to advanced mode for complex expressions (ranges, steps, etc.).
+         */
+        fun fromCronExpression(cron: String): ScheduleBuilderState {
+            if (cron.isBlank()) return ScheduleBuilderState()
+
+            val parts = cron.trim().split("\\s+".toRegex())
+            if (parts.size != 5) {
+                return ScheduleBuilderState(useAdvancedMode = true, rawCronExpression = cron)
+            }
+
+            val (minutePart, hourPart, domPart, monthPart, dowPart) = parts
+
+            // If month field isn't wildcard, fall back to advanced
+            if (monthPart != "*") {
+                return ScheduleBuilderState(useAdvancedMode = true, rawCronExpression = cron)
+            }
+
+            // Parse minute — must be a single number (no lists, ranges, steps)
+            val minute = minutePart.toIntOrNull()
+            if (minute == null || minute !in 0..59) {
+                return ScheduleBuilderState(useAdvancedMode = true, rawCronExpression = cron)
+            }
+
+            // Parse hours — must be a comma-separated list of numbers
+            val hours = parseNumberList(hourPart, 0..23)
+                ?: return ScheduleBuilderState(useAdvancedMode = true, rawCronExpression = cron)
+
+            // Determine schedule type based on DOM and DOW fields
+            val isDomWild = domPart == "*"
+            val isDowWild = dowPart == "*"
+
+            return when {
+                // "m h * * *" → daily
+                isDomWild && isDowWild -> ScheduleBuilderState(
+                    scheduleType = ScheduleType.DAILY,
+                    selectedMinute = minute,
+                    selectedHours = hours
+                )
+                // "m h * * d,d,d" → days of week
+                isDomWild && !isDowWild -> {
+                    val dows = parseNumberList(dowPart, 0..7)
+                        ?: return ScheduleBuilderState(useAdvancedMode = true, rawCronExpression = cron)
+                    // Normalize DOW 7 (some crons use 7=Sun) to 0
+                    val normalizedDows = dows.map { if (it == 7) 0 else it }.toSet()
+                    ScheduleBuilderState(
+                        scheduleType = ScheduleType.DAYS_OF_WEEK,
+                        selectedMinute = minute,
+                        selectedHours = hours,
+                        selectedDaysOfWeek = normalizedDows
+                    )
+                }
+                // "m h d,d * *" → days of month
+                !isDomWild && isDowWild -> {
+                    val doms = parseNumberList(domPart, 1..31)
+                        ?: return ScheduleBuilderState(useAdvancedMode = true, rawCronExpression = cron)
+                    ScheduleBuilderState(
+                        scheduleType = ScheduleType.DAYS_OF_MONTH,
+                        selectedMinute = minute,
+                        selectedHours = hours,
+                        selectedDaysOfMonth = doms
+                    )
+                }
+                // Both DOM and DOW specified — too complex
+                else -> ScheduleBuilderState(useAdvancedMode = true, rawCronExpression = cron)
+            }
+        }
+
+        /**
+         * Parse a CRON field as a comma-separated list of plain integers within [range].
+         * Returns null if the field contains ranges, steps, or wildcards.
+         */
+        private fun parseNumberList(field: String, range: IntRange): Set<Int>? {
+            if (field.contains('-') || field.contains('/') || field.contains('*')) return null
+            val numbers = field.split(',').map { it.trim() }
+            val result = mutableSetOf<Int>()
+            for (num in numbers) {
+                val n = num.toIntOrNull() ?: return null
+                if (n !in range) return null
+                result.add(n)
+            }
+            return if (result.isEmpty()) null else result
+        }
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/exchange/ExchangeApi.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/exchange/ExchangeApi.kt
@@ -4,8 +4,10 @@ import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.domain.model.DcaResult
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.ExchangeCredentials
+import com.accbot.dca.domain.model.TradeHistoryPage
 import okhttp3.OkHttpClient
 import java.math.BigDecimal
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -57,6 +59,24 @@ interface ExchangeApi {
      * Validate credentials (test API connection)
      */
     suspend fun validateCredentials(): Boolean
+
+    /**
+     * Get trade history for a currency pair.
+     * Not all exchanges support this - default throws UnsupportedOperationException.
+     * @param crypto Cryptocurrency symbol (e.g., "BTC")
+     * @param fiat Fiat currency (e.g., "EUR")
+     * @param sinceTimestamp Only return trades after this timestamp (for incremental import)
+     * @param limit Maximum number of trades per page
+     * @return A page of historical trades
+     */
+    suspend fun getTradeHistory(
+        crypto: String,
+        fiat: String,
+        sinceTimestamp: Instant? = null,
+        limit: Int = 100
+    ): TradeHistoryPage = throw UnsupportedOperationException(
+        "${exchange.displayName} does not support API trade history import"
+    )
 }
 
 /**

--- a/accbot-android/app/src/main/java/com/accbot/dca/exchange/MinOrderSizeRepository.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/exchange/MinOrderSizeRepository.kt
@@ -1,0 +1,163 @@
+package com.accbot.dca.exchange
+
+import android.util.Log
+import com.accbot.dca.domain.model.Exchange
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository for fetching minimum order sizes from exchange APIs.
+ * Caches results for 1 hour, falls back to hardcoded Exchange.minOrderSize on failure.
+ */
+@Singleton
+class MinOrderSizeRepository @Inject constructor(
+    private val okHttpClient: OkHttpClient
+) {
+    private data class CachedValue(val minOrderSize: BigDecimal, val timestamp: Long)
+
+    private val cache = ConcurrentHashMap<String, CachedValue>()
+    private val cacheTtlMs = 3_600_000L // 1 hour
+
+    /**
+     * Get the minimum order size in fiat for a given exchange/crypto/fiat combination.
+     * Returns the API-fetched value (cached), or falls back to Exchange.minOrderSize.
+     */
+    suspend fun getMinOrderSize(exchange: Exchange, crypto: String, fiat: String): BigDecimal {
+        val cacheKey = "${exchange}_${crypto}_${fiat}"
+        val now = System.currentTimeMillis()
+
+        // Check cache
+        cache[cacheKey]?.let { cached ->
+            if (now - cached.timestamp < cacheTtlMs) {
+                return cached.minOrderSize
+            }
+        }
+
+        // Fetch from API
+        val fetched = try {
+            when (exchange) {
+                Exchange.COINMATE -> fetchCoinmateMinOrder(crypto, fiat)
+                Exchange.BINANCE -> fetchBinanceMinOrder(crypto, fiat)
+                else -> null
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch min order size for $cacheKey", e)
+            null
+        }
+
+        val result = fetched ?: exchange.minOrderSize[fiat] ?: BigDecimal.ONE
+
+        // Cache the result
+        cache[cacheKey] = CachedValue(result, now)
+
+        return result
+    }
+
+    /**
+     * Coinmate: GET /tradingPairs → minAmount (crypto), then multiply by current price.
+     */
+    private suspend fun fetchCoinmateMinOrder(crypto: String, fiat: String): BigDecimal? =
+        withContext(Dispatchers.IO) {
+            val baseUrl = ExchangeConfig.getBaseUrl(Exchange.COINMATE, false)
+            val pair = "${crypto}_${fiat}"
+
+            // 1. Get minAmount from trading pairs
+            val pairsRequest = Request.Builder()
+                .url("$baseUrl/tradingPairs")
+                .get()
+                .build()
+
+            val pairsResponse = okHttpClient.newCall(pairsRequest).execute()
+            if (!pairsResponse.isSuccessful) return@withContext null
+
+            val pairsBody = pairsResponse.body.string()
+            val pairsJson = JSONObject(pairsBody)
+            val pairsData = pairsJson.optJSONArray("data") ?: return@withContext null
+
+            var minAmount: BigDecimal? = null
+            for (i in 0 until pairsData.length()) {
+                val pairObj = pairsData.getJSONObject(i)
+                if (pairObj.getString("name") == pair) {
+                    minAmount = BigDecimal(pairObj.getString("minAmount"))
+                    break
+                }
+            }
+            if (minAmount == null) return@withContext null
+
+            // 2. Get current price from ticker
+            val tickerRequest = Request.Builder()
+                .url("$baseUrl/ticker?currencyPair=$pair")
+                .get()
+                .build()
+
+            val tickerResponse = okHttpClient.newCall(tickerRequest).execute()
+            if (!tickerResponse.isSuccessful) return@withContext null
+
+            val tickerBody = tickerResponse.body.string()
+            val tickerJson = JSONObject(tickerBody)
+            val tickerData = tickerJson.optJSONObject("data") ?: return@withContext null
+            val lastPrice = BigDecimal(tickerData.getString("last"))
+
+            // 3. minAmount (crypto) × price = minimum fiat amount, rounded up
+            val minFiat = minAmount.multiply(lastPrice).setScale(2, RoundingMode.UP)
+            // buyInstant enforces a separate minimum fiat total, not exposed via API.
+            val instantBuyFloor = COINMATE_INSTANT_BUY_MIN[fiat]
+            val result = if (instantBuyFloor != null) maxOf(minFiat, instantBuyFloor) else minFiat
+            Log.d(TAG, "Coinmate $pair: minAmount=$minAmount, price=$lastPrice, minFiat=$minFiat, floor=$instantBuyFloor, result=$result")
+            result
+        }
+
+    /**
+     * Binance: GET /api/v3/exchangeInfo → NOTIONAL filter → minNotional (fiat).
+     */
+    private suspend fun fetchBinanceMinOrder(crypto: String, fiat: String): BigDecimal? =
+        withContext(Dispatchers.IO) {
+            val baseUrl = ExchangeConfig.getBaseUrl(Exchange.BINANCE, false)
+            val symbol = "${crypto}${fiat}" // Binance uses no underscore
+
+            val request = Request.Builder()
+                .url("$baseUrl/api/v3/exchangeInfo?symbol=$symbol")
+                .get()
+                .build()
+
+            val response = okHttpClient.newCall(request).execute()
+            if (!response.isSuccessful) return@withContext null
+
+            val body = response.body.string()
+            val json = JSONObject(body)
+            val symbols = json.optJSONArray("symbols")
+            if (symbols == null || symbols.length() == 0) return@withContext null
+
+            val symbolObj = symbols.getJSONObject(0)
+            val filters = symbolObj.getJSONArray("filters")
+
+            for (i in 0 until filters.length()) {
+                val filter = filters.getJSONObject(i)
+                if (filter.getString("filterType") == "NOTIONAL") {
+                    val minNotional = BigDecimal(filter.getString("minNotional"))
+                    Log.d(TAG, "Binance $symbol: minNotional=$minNotional")
+                    return@withContext minNotional
+                }
+            }
+
+            null
+        }
+
+    companion object {
+        private const val TAG = "MinOrderSizeRepo"
+
+        // Coinmate buyInstant minimum fiat total (not exposed via /tradingPairs API).
+        // Only CZK is confirmed; EUR is left to the dynamic calculation.
+        private val COINMATE_INSTANT_BUY_MIN = mapOf(
+            "CZK" to BigDecimal("50")
+        )
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/QrScanner.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/QrScanner.kt
@@ -8,13 +8,22 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import com.accbot.dca.R
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material3.*
@@ -25,19 +34,31 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.content.ContextCompat
 import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.accbot.dca.presentation.ui.theme.accentColor
+import com.accbot.dca.presentation.ui.theme.successColor
 import java.util.concurrent.Executors
+
+private enum class ScanMode { QR, TEXT }
+
+/**
+ * Target field for multi-field scanning.
+ * @param label Display label for the field chip
+ * @param key Unique key to identify the field in the result map
+ */
+data class ScanTargetField(val label: String, val key: String)
 
 /**
  * Button that opens QR scanner when clicked.
@@ -75,7 +96,7 @@ fun QrScannerButton(
 }
 
 /**
- * Full-screen dialog with camera preview for QR code scanning.
+ * Full-screen dialog with camera preview for QR code and text scanning.
  */
 @Composable
 fun QrScannerDialog(
@@ -104,6 +125,10 @@ fun QrScannerDialog(
         }
     }
 
+    var scanMode by remember { mutableStateOf(ScanMode.QR) }
+    // Detected text blocks in TEXT mode
+    var detectedTexts by remember { mutableStateOf<List<String>>(emptyList()) }
+
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(
@@ -118,9 +143,17 @@ fun QrScannerDialog(
                 .background(Color.Black)
         ) {
             if (hasCameraPermission) {
-                CameraPreviewWithScanner(
-                    onScanResult = onScanResult
-                )
+                // Camera preview - key on scanMode to force recreation when mode changes
+                key(scanMode) {
+                    when (scanMode) {
+                        ScanMode.QR -> CameraPreviewWithQrScanner(
+                            onScanResult = onScanResult
+                        )
+                        ScanMode.TEXT -> CameraPreviewWithTextScanner(
+                            onTextsDetected = { texts -> detectedTexts = texts }
+                        )
+                    }
+                }
             } else {
                 // Permission not granted
                 Column(
@@ -161,65 +194,672 @@ fun QrScannerDialog(
                 }
             }
 
-            // Close button
-            IconButton(
-                onClick = onDismiss,
+            // Top bar: Close button + Mode toggle
+            Row(
                 modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(16.dp)
-                    .size(48.dp)
-                    .background(
-                        color = Color.Black.copy(alpha = 0.5f),
-                        shape = RoundedCornerShape(24.dp)
-                    )
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(R.string.qr_close_scanner),
-                    tint = Color.White
+                // Spacer for symmetry
+                Spacer(modifier = Modifier.size(48.dp))
+
+                // Mode toggle
+                if (hasCameraPermission) {
+                    Row(
+                        modifier = Modifier
+                            .background(
+                                color = Color.Black.copy(alpha = 0.6f),
+                                shape = RoundedCornerShape(24.dp)
+                            )
+                            .padding(4.dp)
+                    ) {
+                        ModeChip(
+                            text = stringResource(R.string.qr_mode_qr),
+                            isSelected = scanMode == ScanMode.QR,
+                            onClick = {
+                                scanMode = ScanMode.QR
+                                detectedTexts = emptyList()
+                            }
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        ModeChip(
+                            text = stringResource(R.string.qr_mode_text),
+                            isSelected = scanMode == ScanMode.TEXT,
+                            onClick = { scanMode = ScanMode.TEXT }
+                        )
+                    }
+                }
+
+                // Close button
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(
+                            color = Color.Black.copy(alpha = 0.5f),
+                            shape = RoundedCornerShape(24.dp)
+                        )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.qr_close_scanner),
+                        tint = Color.White
+                    )
+                }
+            }
+
+            // Bottom section
+            if (hasCameraPermission) {
+                when (scanMode) {
+                    ScanMode.QR -> {
+                        // QR instructions + scan frame
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(32.dp)
+                                .background(
+                                    color = Color.Black.copy(alpha = 0.6f),
+                                    shape = RoundedCornerShape(16.dp)
+                                )
+                                .padding(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                text = stringResource(R.string.qr_point_camera),
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = stringResource(R.string.qr_scanning_auto),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = 0.7f)
+                            )
+                        }
+
+                        // Scan frame overlay
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .size(250.dp)
+                                .clip(RoundedCornerShape(16.dp))
+                        ) {
+                            ScanFrameCorners()
+                        }
+                    }
+                    ScanMode.TEXT -> {
+                        // Text scan reticle overlay
+                        TextScanReticle(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(bottom = 140.dp)
+                        )
+
+                        // Text mode: show detected texts as selectable items
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .fillMaxWidth()
+                                .heightIn(max = 280.dp)
+                                .background(
+                                    color = Color.Black.copy(alpha = 0.8f),
+                                    shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+                                )
+                                .padding(16.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.qr_point_camera_text),
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = stringResource(R.string.qr_tap_to_select),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = 0.7f)
+                            )
+
+                            if (detectedTexts.isNotEmpty()) {
+                                Spacer(modifier = Modifier.height(12.dp))
+                                LazyColumn(
+                                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    items(detectedTexts) { text ->
+                                        Card(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .clickable { onScanResult(text) },
+                                            colors = CardDefaults.cardColors(
+                                                containerColor = Color.White.copy(alpha = 0.15f)
+                                            )
+                                        ) {
+                                            Text(
+                                                text = text,
+                                                modifier = Modifier.padding(12.dp),
+                                                color = Color.White,
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                maxLines = 2,
+                                                overflow = TextOverflow.Ellipsis
+                                            )
+                                        }
+                                    }
+                                }
+                            } else {
+                                Spacer(modifier = Modifier.height(12.dp))
+                                Text(
+                                    text = stringResource(R.string.qr_no_text_detected),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = Color.White.copy(alpha = 0.5f)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Multi-field scanner dialog for scanning multiple credentials at once.
+ * Shows field assignment chips and lets user assign detected texts to fields.
+ */
+@Composable
+fun MultiFieldScannerDialog(
+    targetFields: List<ScanTargetField>,
+    onDismiss: () -> Unit,
+    onResult: (Map<String, String>) -> Unit
+) {
+    val context = LocalContext.current
+    var hasCameraPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        hasCameraPermission = isGranted
+    }
+
+    LaunchedEffect(Unit) {
+        if (!hasCameraPermission) {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    var scanMode by remember { mutableStateOf(ScanMode.TEXT) }
+    var detectedTexts by remember { mutableStateOf<List<String>>(emptyList()) }
+    var assignments by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var activeFieldKey by remember { mutableStateOf(targetFields.firstOrNull()?.key) }
+
+    val assignedCount = assignments.count { it.value.isNotBlank() }
+    val totalCount = targetFields.size
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+        ) {
+            if (hasCameraPermission) {
+                key(scanMode) {
+                    when (scanMode) {
+                        ScanMode.QR -> CameraPreviewWithQrScanner(
+                            onScanResult = { value ->
+                                activeFieldKey?.let { key ->
+                                    val cleanValue = cleanQrValue(value)
+                                    assignments = assignments + (key to cleanValue)
+                                    // Auto-advance to next empty field
+                                    val nextEmpty = targetFields.firstOrNull { f ->
+                                        f.key != key && !assignments.containsKey(f.key)
+                                    }
+                                    activeFieldKey = nextEmpty?.key
+                                }
+                            }
+                        )
+                        ScanMode.TEXT -> CameraPreviewWithTextScanner(
+                            onTextsDetected = { texts -> detectedTexts = texts }
+                        )
+                    }
+                }
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.QrCodeScanner,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = Color.White
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.qr_camera_permission_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.qr_camera_permission_text),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Button(
+                        onClick = { permissionLauncher.launch(Manifest.permission.CAMERA) },
+                        colors = ButtonDefaults.buttonColors(containerColor = accentColor())
+                    ) {
+                        Text(stringResource(R.string.qr_grant_permission))
+                    }
+                }
+            }
+
+            // Top bar: Close button + Mode toggle
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Spacer(modifier = Modifier.size(48.dp))
+
+                if (hasCameraPermission) {
+                    Row(
+                        modifier = Modifier
+                            .background(
+                                color = Color.Black.copy(alpha = 0.6f),
+                                shape = RoundedCornerShape(24.dp)
+                            )
+                            .padding(4.dp)
+                    ) {
+                        ModeChip(
+                            text = stringResource(R.string.qr_mode_qr),
+                            isSelected = scanMode == ScanMode.QR,
+                            onClick = {
+                                scanMode = ScanMode.QR
+                                detectedTexts = emptyList()
+                            }
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        ModeChip(
+                            text = stringResource(R.string.qr_mode_text),
+                            isSelected = scanMode == ScanMode.TEXT,
+                            onClick = { scanMode = ScanMode.TEXT }
+                        )
+                    }
+                }
+
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(
+                            color = Color.Black.copy(alpha = 0.5f),
+                            shape = RoundedCornerShape(24.dp)
+                        )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.qr_close_scanner),
+                        tint = Color.White
+                    )
+                }
+            }
+
+            // Text scan reticle for TEXT mode
+            if (hasCameraPermission && scanMode == ScanMode.TEXT) {
+                TextScanReticle(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(bottom = 160.dp)
                 )
             }
 
-            // Scan instructions
+            // QR scan frame for QR mode
+            if (hasCameraPermission && scanMode == ScanMode.QR) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(bottom = 80.dp)
+                        .size(250.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                ) {
+                    ScanFrameCorners()
+                }
+            }
+
+            // Bottom sheet with field chips and detected texts
             if (hasCameraPermission) {
                 Column(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
-                        .padding(32.dp)
+                        .fillMaxWidth()
+                        .heightIn(max = 360.dp)
                         .background(
-                            color = Color.Black.copy(alpha = 0.6f),
-                            shape = RoundedCornerShape(16.dp)
+                            color = Color.Black.copy(alpha = 0.85f),
+                            shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
                         )
-                        .padding(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                        .padding(16.dp)
                 ) {
+                    // Header
                     Text(
-                        text = stringResource(R.string.qr_point_camera),
+                        text = stringResource(R.string.qr_assign_to_fields),
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = Color.White
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = stringResource(R.string.qr_scanning_auto),
+                        text = stringResource(R.string.qr_tap_field_then_text),
                         style = MaterialTheme.typography.bodySmall,
                         color = Color.White.copy(alpha = 0.7f)
                     )
-                }
 
-                // Scan frame overlay
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .size(250.dp)
-                        .clip(RoundedCornerShape(16.dp))
-                ) {
-                    // Corner indicators
-                    ScanFrameCorners()
+                    // Field chips
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        for (field in targetFields) {
+                            val assignedValue = assignments[field.key]
+                            val isActive = activeFieldKey == field.key
+                            val isAssigned = !assignedValue.isNullOrBlank()
+
+                            FieldChip(
+                                label = field.label,
+                                assignedValue = assignedValue,
+                                isActive = isActive,
+                                isAssigned = isAssigned,
+                                onClick = {
+                                    if (isAssigned) {
+                                        // Clear assignment and make active
+                                        assignments = assignments - field.key
+                                        activeFieldKey = field.key
+                                    } else {
+                                        activeFieldKey = field.key
+                                    }
+                                }
+                            )
+                        }
+                    }
+
+                    // Detected text cards
+                    Spacer(modifier = Modifier.height(12.dp))
+                    if (scanMode == ScanMode.TEXT) {
+                        if (detectedTexts.isNotEmpty()) {
+                            LazyColumn(
+                                modifier = Modifier.weight(1f, fill = false),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                items(detectedTexts) { text ->
+                                    Card(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable(enabled = activeFieldKey != null) {
+                                                activeFieldKey?.let { key ->
+                                                    assignments = assignments + (key to text)
+                                                    // Auto-advance to next empty field
+                                                    val nextEmpty =
+                                                        targetFields.firstOrNull { f ->
+                                                            f.key != key && assignments[f.key].isNullOrBlank()
+                                                        }
+                                                    activeFieldKey = nextEmpty?.key
+                                                }
+                                            },
+                                        colors = CardDefaults.cardColors(
+                                            containerColor = Color.White.copy(alpha = 0.15f)
+                                        )
+                                    ) {
+                                        Text(
+                                            text = text,
+                                            modifier = Modifier.padding(12.dp),
+                                            color = Color.White,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            maxLines = 2,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                    }
+                                }
+                            }
+                        } else {
+                            Text(
+                                text = stringResource(R.string.qr_no_text_detected),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = 0.5f)
+                            )
+                        }
+                    }
+
+                    // Done button
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Button(
+                        onClick = { onResult(assignments) },
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = assignedCount > 0,
+                        colors = ButtonDefaults.buttonColors(containerColor = accentColor())
+                    ) {
+                        Text(
+                            text = stringResource(R.string.qr_done_count, assignedCount, totalCount)
+                        )
+                    }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun FieldChip(
+    label: String,
+    assignedValue: String?,
+    isActive: Boolean,
+    isAssigned: Boolean,
+    onClick: () -> Unit
+) {
+    val accent = accentColor()
+    val success = successColor()
+
+    val backgroundColor = when {
+        isAssigned -> success
+        isActive -> accent
+        else -> Color.Transparent
+    }
+    val borderColor = when {
+        isAssigned -> success
+        isActive -> accent
+        else -> Color.White.copy(alpha = 0.5f)
+    }
+
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(backgroundColor.copy(alpha = if (isAssigned || isActive) 1f else 0f))
+            .border(
+                width = 1.dp,
+                color = if (isAssigned || isActive) Color.Transparent else borderColor,
+                shape = RoundedCornerShape(20.dp)
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (isActive && !isAssigned) {
+            Text(
+                text = "\u25B8 ",
+                color = Color.White,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Bold
+            )
+        }
+        if (isAssigned) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = Color.White
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+        }
+        Text(
+            text = if (isAssigned) "$label: ${assignedValue?.take(12)}..." else label,
+            color = Color.White,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = if (isActive || isAssigned) FontWeight.SemiBold else FontWeight.Normal,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/**
+ * Horizontal reticle overlay for TEXT scan mode.
+ * Shows corner brackets indicating the text scanning area.
+ */
+@Composable
+private fun TextScanReticle(modifier: Modifier = Modifier) {
+    val cornerColor = accentColor()
+    val cornerSize = 32.dp
+    val cornerWidth = 3.dp
+
+    Box(
+        modifier = modifier
+            .width(280.dp)
+            .height(80.dp)
+    ) {
+        // Top-left corner
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .size(cornerSize)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(cornerWidth)
+                    .background(cornerColor)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .width(cornerWidth)
+                    .background(cornerColor)
+            )
+        }
+
+        // Top-right corner
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .size(cornerSize)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(cornerWidth)
+                    .background(cornerColor)
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .fillMaxHeight()
+                    .width(cornerWidth)
+                    .background(cornerColor)
+            )
+        }
+
+        // Bottom-left corner
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .size(cornerSize)
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .height(cornerWidth)
+                    .background(cornerColor)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .width(cornerWidth)
+                    .background(cornerColor)
+            )
+        }
+
+        // Bottom-right corner
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .size(cornerSize)
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .fillMaxWidth()
+                    .height(cornerWidth)
+                    .background(cornerColor)
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .fillMaxHeight()
+                    .width(cornerWidth)
+                    .background(cornerColor)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ModeChip(
+    text: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Text(
+        text = text,
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(
+                if (isSelected) accentColor() else Color.Transparent
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        color = Color.White,
+        style = MaterialTheme.typography.bodySmall,
+        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+    )
 }
 
 @Composable
@@ -317,7 +957,7 @@ private fun ScanFrameCorners() {
 
 @Composable
 @androidx.annotation.OptIn(androidx.camera.core.ExperimentalGetImage::class)
-private fun CameraPreviewWithScanner(
+internal fun CameraPreviewWithQrScanner(
     onScanResult: (String) -> Unit
 ) {
     val context = LocalContext.current
@@ -325,6 +965,15 @@ private fun CameraPreviewWithScanner(
 
     val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
     var hasScanned by remember { mutableStateOf(false) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            try {
+                val cameraProvider = cameraProviderFuture.get()
+                cameraProvider.unbindAll()
+            } catch (_: Exception) {}
+        }
+    }
 
     AndroidView(
         factory = { ctx ->
@@ -347,7 +996,16 @@ private fun CameraPreviewWithScanner(
             val executor = Executors.newSingleThreadExecutor()
 
             val imageAnalysis = ImageAnalysis.Builder()
-                .setTargetResolution(Size(1280, 720))
+                .setResolutionSelector(
+                    ResolutionSelector.Builder()
+                        .setResolutionStrategy(
+                            ResolutionStrategy(
+                                Size(1280, 720),
+                                ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER
+                            )
+                        )
+                        .build()
+                )
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                 .build()
 
@@ -365,12 +1023,113 @@ private fun CameraPreviewWithScanner(
                                 barcode.rawValue?.let { value ->
                                     if (!hasScanned) {
                                         hasScanned = true
-                                        // Clean up the scanned value (remove bitcoin: prefix if present)
                                         val cleanValue = cleanQrValue(value)
                                         onScanResult(cleanValue)
                                     }
                                 }
                             }
+                        }
+                        .addOnCompleteListener {
+                            imageProxy.close()
+                        }
+                } else {
+                    imageProxy.close()
+                }
+            }
+
+            val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+            try {
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(
+                    lifecycleOwner,
+                    cameraSelector,
+                    preview,
+                    imageAnalysis
+                )
+            } catch (e: Exception) {
+                // Camera initialization failed
+            }
+        }, ContextCompat.getMainExecutor(context))
+    }
+}
+
+@Composable
+@androidx.annotation.OptIn(androidx.camera.core.ExperimentalGetImage::class)
+internal fun CameraPreviewWithTextScanner(
+    onTextsDetected: (List<String>) -> Unit
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            try {
+                val cameraProvider = cameraProviderFuture.get()
+                cameraProvider.unbindAll()
+            } catch (_: Exception) {}
+        }
+    }
+
+    AndroidView(
+        factory = { ctx ->
+            PreviewView(ctx).apply {
+                implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) { previewView ->
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+
+            val preview = Preview.Builder()
+                .build()
+                .also {
+                    it.setSurfaceProvider(previewView.surfaceProvider)
+                }
+
+            val textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+            val executor = Executors.newSingleThreadExecutor()
+
+            val imageAnalysis = ImageAnalysis.Builder()
+                .setResolutionSelector(
+                    ResolutionSelector.Builder()
+                        .setResolutionStrategy(
+                            ResolutionStrategy(
+                                Size(1280, 720),
+                                ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER
+                            )
+                        )
+                        .build()
+                )
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+
+            imageAnalysis.setAnalyzer(executor) { imageProxy ->
+                val mediaImage = imageProxy.image
+                if (mediaImage != null) {
+                    val image = InputImage.fromMediaImage(
+                        mediaImage,
+                        imageProxy.imageInfo.rotationDegrees
+                    )
+
+                    textRecognizer.process(image)
+                        .addOnSuccessListener { visionText ->
+                            // Filter text blocks: only show those with 8+ alphanumeric chars
+                            // (API keys/secrets are typically long alphanumeric strings)
+                            val candidates = visionText.textBlocks
+                                .flatMap { block ->
+                                    block.lines.map { line -> line.text.trim() }
+                                }
+                                .filter { text ->
+                                    val alphanumCount = text.count { it.isLetterOrDigit() }
+                                    alphanumCount >= 8 && text.length <= 256
+                                }
+                                .distinct()
+
+                            onTextsDetected(candidates)
                         }
                         .addOnCompleteListener {
                             imageProxy.close()

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ScheduleBuilder.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ScheduleBuilder.kt
@@ -1,0 +1,374 @@
+package com.accbot.dca.presentation.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.accbot.dca.R
+import com.accbot.dca.domain.util.CronUtils
+import com.accbot.dca.domain.util.ScheduleBuilderState
+import com.accbot.dca.domain.util.ScheduleType
+import com.accbot.dca.presentation.ui.theme.successColor
+import java.time.DayOfWeek
+import java.time.format.TextStyle
+import java.util.Locale
+
+/**
+ * Visual schedule builder — drop-in replacement for CronExpressionInput.
+ * Same signature: takes a CRON string in, emits a CRON string out.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ScheduleBuilder(
+    cronExpression: String,
+    cronDescription: String?,
+    cronError: String?,
+    onCronExpressionChange: (String) -> Unit
+) {
+    var state by remember(cronExpression) {
+        mutableStateOf(ScheduleBuilderState.fromCronExpression(cronExpression))
+    }
+
+    // Emit CRON whenever state changes
+    fun emitCron(newState: ScheduleBuilderState) {
+        state = newState
+        val cron = newState.toCronExpression()
+        if (cron != null) {
+            onCronExpressionChange(cron)
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+
+        // ── Schedule Type Selector ──
+        if (!state.useAdvancedMode) {
+            Text(
+                text = stringResource(R.string.schedule_type_label),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                val types = listOf(
+                    ScheduleType.DAILY to stringResource(R.string.schedule_type_daily),
+                    ScheduleType.DAYS_OF_WEEK to stringResource(R.string.schedule_type_days_of_week),
+                    ScheduleType.DAYS_OF_MONTH to stringResource(R.string.schedule_type_days_of_month)
+                )
+                types.forEachIndexed { index, (type, label) ->
+                    SegmentedButton(
+                        selected = state.scheduleType == type,
+                        onClick = {
+                            emitCron(state.copy(scheduleType = type))
+                        },
+                        shape = SegmentedButtonDefaults.itemShape(index, types.size)
+                    ) {
+                        Text(label, style = MaterialTheme.typography.labelMedium)
+                    }
+                }
+            }
+
+            // ── Time Selection ──
+            Text(
+                text = stringResource(R.string.schedule_time_label),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            // Minute selector
+            Text(
+                text = stringResource(R.string.schedule_minute_label),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(0, 15, 30, 45).forEach { minute ->
+                    SelectableChip(
+                        text = ":%02d".format(minute),
+                        selected = state.selectedMinute == minute,
+                        onClick = { emitCron(state.copy(selectedMinute = minute)) }
+                    )
+                }
+            }
+
+            // Hour selector
+            Text(
+                text = stringResource(R.string.schedule_hour_label),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                (0..23).forEach { hour ->
+                    SelectableChip(
+                        text = "%d:00".format(hour),
+                        selected = hour in state.selectedHours,
+                        onClick = {
+                            val newHours = if (hour in state.selectedHours) {
+                                state.selectedHours - hour
+                            } else {
+                                state.selectedHours + hour
+                            }
+                            emitCron(state.copy(selectedHours = newHours))
+                        }
+                    )
+                }
+            }
+
+            // Time summary
+            if (state.selectedTimes.isNotEmpty()) {
+                Text(
+                    text = state.selectedTimes.joinToString(", ") { it.format() },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = successColor(),
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+
+            // ── Day of Week Selector ──
+            if (state.scheduleType == ScheduleType.DAYS_OF_WEEK) {
+                Text(
+                    text = stringResource(R.string.schedule_select_days),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    // Sunday (0) then Monday-Saturday (1-6)
+                    val dayOrder = listOf(1, 2, 3, 4, 5, 6, 0) // Mon..Sat, Sun
+                    val locale = Locale.getDefault()
+                    dayOrder.forEach { cronDow ->
+                        val javaDow = when (cronDow) {
+                            0 -> DayOfWeek.SUNDAY
+                            1 -> DayOfWeek.MONDAY
+                            2 -> DayOfWeek.TUESDAY
+                            3 -> DayOfWeek.WEDNESDAY
+                            4 -> DayOfWeek.THURSDAY
+                            5 -> DayOfWeek.FRIDAY
+                            6 -> DayOfWeek.SATURDAY
+                            else -> DayOfWeek.MONDAY
+                        }
+                        val dayName = javaDow.getDisplayName(TextStyle.SHORT, locale)
+                        SelectableChip(
+                            text = dayName,
+                            selected = cronDow in state.selectedDaysOfWeek,
+                            onClick = {
+                                val newDays = if (cronDow in state.selectedDaysOfWeek) {
+                                    state.selectedDaysOfWeek - cronDow
+                                } else {
+                                    state.selectedDaysOfWeek + cronDow
+                                }
+                                emitCron(state.copy(selectedDaysOfWeek = newDays))
+                            }
+                        )
+                    }
+                }
+            }
+
+            // ── Day of Month Selector ──
+            if (state.scheduleType == ScheduleType.DAYS_OF_MONTH) {
+                Text(
+                    text = stringResource(R.string.schedule_select_days),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold
+                )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    (1..31).forEach { day ->
+                        SelectableChip(
+                            text = day.toString(),
+                            selected = day in state.selectedDaysOfMonth,
+                            onClick = {
+                                val newDays = if (day in state.selectedDaysOfMonth) {
+                                    state.selectedDaysOfMonth - day
+                                } else {
+                                    state.selectedDaysOfMonth + day
+                                }
+                                emitCron(state.copy(selectedDaysOfMonth = newDays))
+                            }
+                        )
+                    }
+                }
+            }
+
+            // ── CRON Preview ──
+            val generatedCron = state.toCronExpression()
+            if (generatedCron != null) {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.schedule_preview_label),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = generatedCron,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        val description = cronDescription ?: CronUtils.describeCron(generatedCron)
+                        if (description != null) {
+                            Text(
+                                text = description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = successColor()
+                            )
+                        }
+                        if (cronError != null) {
+                            Text(
+                                text = cronError,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Advanced Mode Section ──
+        AdvancedModeSection(
+            isAdvancedMode = state.useAdvancedMode,
+            rawCronExpression = if (state.useAdvancedMode) state.rawCronExpression else (state.toCronExpression() ?: ""),
+            cronDescription = cronDescription,
+            cronError = cronError,
+            onToggle = {
+                if (state.useAdvancedMode) {
+                    // Switching from advanced → visual: try to parse current raw CRON
+                    val parsed = ScheduleBuilderState.fromCronExpression(state.rawCronExpression)
+                    if (!parsed.useAdvancedMode) {
+                        emitCron(parsed)
+                    } else {
+                        // Can't parse back to visual, stay in advanced
+                        emitCron(state)
+                    }
+                } else {
+                    // Switching from visual → advanced: keep current CRON in raw field
+                    val cron = state.toCronExpression() ?: ""
+                    emitCron(state.copy(useAdvancedMode = true, rawCronExpression = cron))
+                }
+            },
+            onRawCronChange = { newCron ->
+                emitCron(state.copy(rawCronExpression = newCron))
+            }
+        )
+    }
+}
+
+@Composable
+private fun AdvancedModeSection(
+    isAdvancedMode: Boolean,
+    rawCronExpression: String,
+    cronDescription: String?,
+    cronError: String?,
+    onToggle: () -> Unit,
+    onRawCronChange: (String) -> Unit
+) {
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onToggle)
+                .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.schedule_advanced_label),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Icon(
+                imageVector = if (isAdvancedMode) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        AnimatedVisibility(visible = isAdvancedMode) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = rawCronExpression,
+                    onValueChange = onRawCronChange,
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text(stringResource(R.string.cron_input_label)) },
+                    placeholder = { Text(stringResource(R.string.cron_input_hint)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                    isError = cronError != null,
+                    supportingText = when {
+                        cronError != null -> {
+                            { Text(cronError, color = MaterialTheme.colorScheme.error) }
+                        }
+                        cronDescription != null -> {
+                            { Text(cronDescription, color = successColor()) }
+                        }
+                        else -> null
+                    }
+                )
+
+                // CRON examples card
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.cron_examples_title),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(R.string.cron_example_daily),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = stringResource(R.string.cron_example_weekly),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = stringResource(R.string.cron_example_monthly),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = stringResource(R.string.cron_example_twice_daily),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.DcaStrategy
@@ -30,6 +30,7 @@ import com.accbot.dca.presentation.components.MonthlyCostEstimateCard
 import com.accbot.dca.presentation.components.QrScannerButton
 import com.accbot.dca.presentation.components.SandboxCredentialsInfoCard
 import com.accbot.dca.presentation.components.SandboxModeIndicator
+import com.accbot.dca.presentation.components.ScheduleBuilder
 import com.accbot.dca.presentation.components.SelectableChip
 import com.accbot.dca.presentation.components.StrategyInfoBottomSheet
 import com.accbot.dca.presentation.ui.theme.accentColor
@@ -149,7 +150,17 @@ fun AddPlanScreen(
                     label = { Text(stringResource(R.string.common_amount)) },
                     suffix = { Text(uiState.selectedFiat) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                    singleLine = true
+                    singleLine = true,
+                    isError = uiState.amountBelowMinimum,
+                    supportingText = uiState.minOrderSize?.let { min ->
+                        {
+                            Text(
+                                text = stringResource(R.string.min_order_size, min.toPlainString(), uiState.selectedFiat),
+                                color = if (uiState.amountBelowMinimum) MaterialTheme.colorScheme.error
+                                        else MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 )
 
                 // Frequency Selection - Dropdown
@@ -158,6 +169,16 @@ fun AddPlanScreen(
                     selectedFrequency = uiState.selectedFrequency,
                     onFrequencySelected = viewModel::selectFrequency
                 )
+
+                // Schedule Builder (when Custom frequency is selected)
+                if (uiState.selectedFrequency == DcaFrequency.CUSTOM) {
+                    ScheduleBuilder(
+                        cronExpression = uiState.cronExpression,
+                        cronDescription = uiState.cronDescription,
+                        cronError = uiState.cronError,
+                        onCronExpressionChange = viewModel::setCronExpression
+                    )
+                }
 
                 // Strategy Selection
                 SectionTitle(stringResource(R.string.add_plan_dca_strategy))
@@ -448,4 +469,5 @@ private fun StrategyOption(
         }
     }
 }
+
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/HistoryScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/HistoryScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.data.local.TransactionEntity
 import com.accbot.dca.domain.model.TransactionStatus

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/ImportCsvScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/ImportCsvScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.presentation.components.AccBotTopAppBar
 import com.accbot.dca.presentation.components.LoadingState

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.ExchangeInstructions

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.presentation.components.AccBotTopAppBar

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/history/TransactionDetailsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/history/TransactionDetailsScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.domain.model.TransactionStatus
 import com.accbot.dca.presentation.components.AccBotTopAppBar

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/CompletionScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/CompletionScreen.kt
@@ -3,6 +3,8 @@ package com.accbot.dca.presentation.screens.onboarding
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -19,7 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.presentation.ui.theme.accentColor
 import com.accbot.dca.presentation.ui.theme.successColor
@@ -56,6 +58,7 @@ fun CompletionScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState())
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -143,7 +146,7 @@ fun CompletionScreen(
             }
         }
 
-        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(24.dp))
 
         // Tips card
         Card(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.presentation.components.QrScannerButton
 import com.accbot.dca.presentation.components.SandboxModeIndicator

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/SecurityScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/SecurityScreen.kt
@@ -4,6 +4,8 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -22,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.presentation.screens.SettingsViewModel
 import com.accbot.dca.presentation.ui.theme.accentColor
@@ -64,6 +66,7 @@ fun SecurityScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
                 .padding(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -189,7 +192,7 @@ fun SecurityScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(24.dp))
 
             // Info card
             Card(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/WelcomeScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/WelcomeScreen.kt
@@ -3,6 +3,8 @@ package com.accbot.dca.presentation.screens.onboarding
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -46,6 +48,7 @@ fun WelcomeScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState())
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -96,7 +99,7 @@ fun WelcomeScreen(
             )
         }
 
-        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(32.dp))
 
         // Continue button
         Button(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/EditPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/EditPlanScreen.kt
@@ -14,10 +14,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.DcaStrategy
+import com.accbot.dca.presentation.components.ScheduleBuilder
 import com.accbot.dca.presentation.components.AccBotTopAppBar
 import com.accbot.dca.presentation.components.LoadingState
 import com.accbot.dca.presentation.components.ErrorState
@@ -130,7 +131,16 @@ fun EditPlanScreen(
                             suffix = { Text(uiState.fiat) },
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                             singleLine = true,
-                            isError = uiState.error != null && uiState.isSaving
+                            isError = uiState.amountBelowMinimum || (uiState.error != null && uiState.isSaving),
+                            supportingText = uiState.minOrderSize?.let { min ->
+                                {
+                                    Text(
+                                        text = stringResource(R.string.min_order_size, min.toPlainString(), uiState.fiat),
+                                        color = if (uiState.amountBelowMinimum) MaterialTheme.colorScheme.error
+                                                else MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
                         )
                     }
 
@@ -150,6 +160,17 @@ fun EditPlanScreen(
                                     onClick = { viewModel.selectFrequency(frequency) }
                                 )
                             }
+                        }
+
+                        // Schedule Builder (when Custom frequency is selected)
+                        if (uiState.selectedFrequency == DcaFrequency.CUSTOM) {
+                            Spacer(modifier = Modifier.height(12.dp))
+                            ScheduleBuilder(
+                                cronExpression = uiState.cronExpression,
+                                cronDescription = uiState.cronDescription,
+                                cronError = uiState.cronError,
+                                onCronExpressionChange = viewModel::setCronExpression
+                            )
                         }
                     }
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/portfolio/PortfolioScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/portfolio/PortfolioScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.sp
 import android.content.res.Configuration
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.domain.usecase.ChartZoomLevel
 import com.accbot.dca.presentation.components.*

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/splash/SplashScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/splash/SplashScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.presentation.ui.theme.accentColor
 import kotlinx.coroutines.delay

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -41,6 +41,8 @@
     <string name="frequency_daily">Denně</string>
     <string name="frequency_weekly">Týdně</string>
 
+    <string name="frequency_custom">Vlastní plán</string>
+
     <!-- Dashboard Screen -->
     <string name="dashboard_add_plan">Přidat plán</string>
     <string name="dashboard_sandbox_banner">SANDBOX REŽIM – Pouze testovací obchody</string>
@@ -62,6 +64,9 @@
     <string name="dashboard_history">Historie</string>
     <string name="dashboard_run_now">Spustit nyní</string>
     <string name="dashboard_dca_triggered">DCA nákup spuštěn</string>
+    <string name="run_now_title">Spustit nyní</string>
+    <string name="run_now_all_plans">Všechny plány</string>
+    <string name="run_now_confirm">Spustit %1$d plán(ů)</string>
     <string name="dashboard_roi">ROI %1$s</string>
     <string name="dashboard_less_than_1_hour">&lt; 1 hodina</string>
     <plurals name="dashboard_hours">
@@ -120,6 +125,8 @@
     <string name="settings_language_system_default">Výchozí systémový</string>
     <string name="settings_language_english">English</string>
     <string name="settings_language_czech">Čeština</string>
+    <string name="settings_notifications">Spravovat oznámení</string>
+    <string name="settings_notifications_subtitle">Nastavení kanálů oznámení a zvuků</string>
 
     <!-- History Screen -->
     <string name="history_title">Historie transakcí</string>
@@ -378,7 +385,7 @@
     <string name="first_plan_what_to_buy">Co nakoupit</string>
     <string name="first_plan_currency">Měna</string>
     <string name="first_plan_custom_amount">Vlastní částka</string>
-    <string name="first_plan_minimum">Minimum: %1$s %2$s</string>
+    <string name="min_order_size">Minimum: %1$s %2$s</string>
     <string name="first_plan_how_often">Jak často</string>
     <string name="first_plan_recommended">Doporučeno pro začátečníky</string>
     <string name="first_plan_lower_frequency">Nižší frekvence, větší nákupy</string>
@@ -445,6 +452,17 @@
     <string name="qr_point_camera">Namiřte fotoaparát na QR kód</string>
     <string name="qr_scanning_auto">Skenování proběhne automaticky</string>
 
+    <string name="qr_point_camera_text">Namiřte fotoaparát na text</string>
+    <string name="qr_tap_to_select">Klepněte na text pro výběr</string>
+    <string name="qr_mode_qr">QR kód</string>
+    <string name="qr_mode_text">Text (OCR)</string>
+    <string name="qr_no_text_detected">Žádný text nedetekován</string>
+    <string name="credentials_scan_all">Skenovat všechny údaje</string>
+    <string name="credentials_scan_all_desc">Skenovat více údajů najednou</string>
+    <string name="qr_assign_to_fields">Přiřaďte text k polím</string>
+    <string name="qr_tap_field_then_text">Vyberte pole a klepněte na text</string>
+    <string name="qr_done_count">Hotovo (%1$d/%2$d)</string>
+
     <!-- Biometric Lock -->
     <string name="biometric_lock_title">Zámek aplikace</string>
     <string name="biometric_lock_subtitle">Vyžadovat biometrické ověření pro otevření AccBot</string>
@@ -480,6 +498,39 @@
     <string name="import_csv_file_loaded">Soubor načten</string>
     <string name="import_csv_plan_info">%1$s/%2$s na %3$s</string>
     <string name="import_csv_instructions">Exportujte historii transakcí z Coinmate a vyberte CSV soubor níže.</string>
+
+    <!-- Import via API -->
+    <string name="import_api_title">Import přes API</string>
+    <string name="import_api_subtitle">Import transakcí jedním kliknutím z burzy</string>
+    <string name="import_api_fetching">Stahování obchodů (stránka %1$d)…</string>
+    <string name="import_api_deduplicating">Kontrola duplicit…</string>
+    <string name="import_api_importing">Importování %1$d transakcí…</string>
+    <string name="import_api_success_title">Import dokončen</string>
+    <string name="import_api_error_title">Import selhal</string>
+    <string name="import_api_success_message">%1$d transakcí importováno, %2$d přeskočeno (již existovaly)</string>
+    <string name="import_api_no_new">Žádné nové transakce k importu</string>
+
+    <!-- Schedule Builder -->
+    <string name="schedule_type_label">Typ rozvrhu</string>
+    <string name="schedule_type_daily">Každý den</string>
+    <string name="schedule_type_days_of_week">Dny v týdnu</string>
+    <string name="schedule_type_days_of_month">Dny v měsíci</string>
+    <string name="schedule_time_label">Čas</string>
+    <string name="schedule_minute_label">Minuta</string>
+    <string name="schedule_hour_label">Hodina (klepněte pro výběr více)</string>
+    <string name="schedule_select_days">Vyberte dny</string>
+    <string name="schedule_preview_label">Náhled rozvrhu</string>
+    <string name="schedule_advanced_label">Pokročilé: Upravit CRON přímo</string>
+
+    <!-- CRON Frequency -->
+    <string name="cron_input_label">CRON výraz</string>
+    <string name="cron_input_hint">např. 0 9 * * 1 (Po 9:00)</string>
+    <string name="cron_invalid">Neplatný CRON výraz</string>
+    <string name="cron_examples_title">Příklady:</string>
+    <string name="cron_example_daily">0 9 * * * = Každý den v 9:00</string>
+    <string name="cron_example_weekly">0 9 * * 1 = Každé pondělí v 9:00</string>
+    <string name="cron_example_monthly">0 9 1 * * = 1. každého měsíce v 9:00</string>
+    <string name="cron_example_twice_daily">0 9,21 * * * = Každý den v 9:00 a 21:00</string>
 
     <!-- Accessibility -->
     <string name="a11y_retry">Opakovat</string>

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="frequency_every_8_hours">Every 8 hours</string>
     <string name="frequency_daily">Daily</string>
     <string name="frequency_weekly">Weekly</string>
+    <string name="frequency_custom">Custom Schedule</string>
 
     <!-- Dashboard Screen -->
     <string name="dashboard_add_plan">Add Plan</string>
@@ -64,6 +65,9 @@
     <string name="dashboard_history">History</string>
     <string name="dashboard_run_now">Run Now</string>
     <string name="dashboard_dca_triggered">DCA execution triggered</string>
+    <string name="run_now_title">Run Now</string>
+    <string name="run_now_all_plans">All plans</string>
+    <string name="run_now_confirm">Run %1$d plan(s)</string>
     <string name="dashboard_roi">ROI %1$s</string>
     <string name="dashboard_less_than_1_hour">&lt; 1 hour</string>
     <plurals name="dashboard_hours">
@@ -120,6 +124,8 @@
     <string name="settings_language_system_default">System default</string>
     <string name="settings_language_english">English</string>
     <string name="settings_language_czech">Čeština</string>
+    <string name="settings_notifications">Manage Notifications</string>
+    <string name="settings_notifications_subtitle">Configure notification channels and sounds</string>
 
     <!-- History Screen -->
     <string name="history_title">Transaction History</string>
@@ -378,7 +384,7 @@
     <string name="first_plan_what_to_buy">What to buy</string>
     <string name="first_plan_currency">Currency</string>
     <string name="first_plan_custom_amount">Custom amount</string>
-    <string name="first_plan_minimum">Minimum: %1$s %2$s</string>
+    <string name="min_order_size">Minimum: %1$s %2$s</string>
     <string name="first_plan_how_often">How often</string>
     <string name="first_plan_recommended">Recommended for beginners</string>
     <string name="first_plan_lower_frequency">Lower frequency, larger purchases</string>
@@ -443,7 +449,17 @@
     <string name="qr_close_scanner">Close scanner</string>
     <string name="qr_camera_permission_title">Camera Permission Required</string>
     <string name="qr_point_camera">Point camera at QR code</string>
+    <string name="qr_point_camera_text">Point camera at text</string>
     <string name="qr_scanning_auto">Scanning will happen automatically</string>
+    <string name="qr_tap_to_select">Tap text to select</string>
+    <string name="qr_mode_qr">QR Code</string>
+    <string name="qr_mode_text">Text (OCR)</string>
+    <string name="qr_no_text_detected">No text detected</string>
+    <string name="credentials_scan_all">Scan All Credentials</string>
+    <string name="credentials_scan_all_desc">Scan multiple credentials at once</string>
+    <string name="qr_assign_to_fields">Assign text to fields</string>
+    <string name="qr_tap_field_then_text">Select a field, then tap detected text</string>
+    <string name="qr_done_count">Done (%1$d/%2$d)</string>
 
     <!-- Biometric Lock -->
     <string name="biometric_lock_title">App Lock</string>
@@ -480,6 +496,39 @@
     <string name="import_csv_file_loaded">File loaded</string>
     <string name="import_csv_plan_info">%1$s/%2$s on %3$s</string>
     <string name="import_csv_instructions">Export your transaction history from Coinmate and select the CSV file below.</string>
+
+    <!-- Schedule Builder -->
+    <string name="schedule_type_label">Schedule Type</string>
+    <string name="schedule_type_daily">Every Day</string>
+    <string name="schedule_type_days_of_week">Days of Week</string>
+    <string name="schedule_type_days_of_month">Days of Month</string>
+    <string name="schedule_time_label">Time</string>
+    <string name="schedule_minute_label">Minute</string>
+    <string name="schedule_hour_label">Hour (tap to select multiple)</string>
+    <string name="schedule_select_days">Select Days</string>
+    <string name="schedule_preview_label">Schedule Preview</string>
+    <string name="schedule_advanced_label">Advanced: Edit CRON directly</string>
+
+    <!-- CRON Frequency -->
+    <string name="cron_input_label">CRON Expression</string>
+    <string name="cron_input_hint">e.g. 0 9 * * 1 (Mon 9:00)</string>
+    <string name="cron_invalid">Invalid CRON expression</string>
+    <string name="cron_examples_title">Examples:</string>
+    <string name="cron_example_daily">0 9 * * * = Every day at 9:00</string>
+    <string name="cron_example_weekly">0 9 * * 1 = Every Monday at 9:00</string>
+    <string name="cron_example_monthly">0 9 1 * * = 1st of every month at 9:00</string>
+    <string name="cron_example_twice_daily">0 9,21 * * * = Every day at 9:00 and 21:00</string>
+
+    <!-- Import via API -->
+    <string name="import_api_title">Import via API</string>
+    <string name="import_api_subtitle">One-click incremental import from exchange</string>
+    <string name="import_api_fetching">Fetching trades (page %1$d)…</string>
+    <string name="import_api_deduplicating">Checking for duplicates…</string>
+    <string name="import_api_importing">Importing %1$d transactions…</string>
+    <string name="import_api_success_title">Import Complete</string>
+    <string name="import_api_error_title">Import Failed</string>
+    <string name="import_api_success_message">%1$d transactions imported, %2$d skipped (already existed)</string>
+    <string name="import_api_no_new">No new transactions to import</string>
 
     <!-- Accessibility -->
     <string name="a11y_retry">Retry</string>

--- a/accbot-android/gradle.properties
+++ b/accbot-android/gradle.properties
@@ -7,6 +7,6 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # App versioning (semver)
-VERSION_MAJOR=1
+VERSION_MAJOR=2
 VERSION_MINOR=0
-VERSION_PATCH=2
+VERSION_PATCH=111


### PR DESCRIPTION
## Summary
- **Fix Coinmate minimum order size**: add `buyInstant` floor (50 CZK) so the app never shows a minimum below the actual exchange limit
- Update Coinmate fallback min order from 250 → 50 CZK
- Add `MinOrderSizeRepository` for dynamic min order fetching from exchange APIs
- Add QR scanner for exchange credential input
- Add CSV trade history import with `ImportTradeHistoryUseCase`
- Add `ScheduleBuilder` component and cron utilities
- Binance/Coinmate API improvements
- Dashboard, portfolio, and plan management UI enhancements
- Czech localization updates
- Bump version to 2.0.111

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [x] Installed on Pixel 8 Pro and verified
- [ ] Verify Coinmate BTC/CZK plan shows ≥ 50 CZK minimum (not ~21 CZK)
- [ ] Verify QR scanner works for credential input
- [ ] Verify CSV import flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)