### PR TITLE
Android v2.0.114: Exchange/crypto/fiat icons, grid layout, icon-only nav

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/MainActivity.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/MainActivity.kt
@@ -138,7 +138,7 @@ fun AccBotApp(
     val currentRoute = navBackStackEntry?.destination?.route
 
     // Determine if bottom nav should be shown
-    val showBottomNav = currentRoute in bottomNavItems.map { it.route }
+    val showBottomNav = bottomNavItems.any { currentRoute?.startsWith(it.route) == true }
 
     // Determine start destination
     val startDestination = if (isOnboardingCompleted) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/model/Models.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/model/Models.kt
@@ -1,5 +1,6 @@
 package com.accbot.dca.domain.model
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.accbot.dca.R
 import java.math.BigDecimal
@@ -20,6 +21,7 @@ enum class SandboxSupport {
  */
 enum class Exchange(
     val displayName: String,
+    @DrawableRes val logoRes: Int,
     val supportedFiats: List<String>,
     val supportedCryptos: List<String>,
     val minOrderSize: Map<String, BigDecimal>,
@@ -27,6 +29,7 @@ enum class Exchange(
 ) {
     COINMATE(
         displayName = "Coinmate",
+        logoRes = R.drawable.ic_exchange_coinmate,
         supportedFiats = listOf("EUR", "CZK"),
         supportedCryptos = listOf("BTC", "ETH", "LTC"),
         minOrderSize = mapOf("EUR" to BigDecimal("10"), "CZK" to BigDecimal("50")),
@@ -34,6 +37,7 @@ enum class Exchange(
     ),
     BINANCE(
         displayName = "Binance",
+        logoRes = R.drawable.ic_exchange_binance,
         supportedFiats = listOf("EUR", "USDT"),
         supportedCryptos = listOf("BTC", "ETH", "SOL", "ADA", "DOT"),
         minOrderSize = mapOf("EUR" to BigDecimal("10"), "USDT" to BigDecimal("10")),
@@ -41,6 +45,7 @@ enum class Exchange(
     ),
     KRAKEN(
         displayName = "Kraken",
+        logoRes = R.drawable.ic_exchange_kraken,
         supportedFiats = listOf("EUR", "USD", "GBP"),
         supportedCryptos = listOf("BTC", "ETH", "SOL", "DOT"),
         minOrderSize = mapOf("EUR" to BigDecimal("10"), "USD" to BigDecimal("10")),
@@ -48,6 +53,7 @@ enum class Exchange(
     ),
     KUCOIN(
         displayName = "KuCoin",
+        logoRes = R.drawable.ic_exchange_kucoin,
         supportedFiats = listOf("USDT"),
         supportedCryptos = listOf("BTC", "ETH", "SOL", "ADA"),
         minOrderSize = mapOf("USDT" to BigDecimal("10")),
@@ -55,6 +61,7 @@ enum class Exchange(
     ),
     BITFINEX(
         displayName = "Bitfinex",
+        logoRes = R.drawable.ic_exchange_bitfinex,
         supportedFiats = listOf("USD", "EUR"),
         supportedCryptos = listOf("BTC", "ETH"),
         minOrderSize = mapOf("USD" to BigDecimal("25"), "EUR" to BigDecimal("25")),
@@ -62,6 +69,7 @@ enum class Exchange(
     ),
     HUOBI(
         displayName = "Huobi",
+        logoRes = R.drawable.ic_exchange_huobi,
         supportedFiats = listOf("USDT"),
         supportedCryptos = listOf("BTC", "ETH", "SOL"),
         minOrderSize = mapOf("USDT" to BigDecimal("10")),
@@ -69,6 +77,7 @@ enum class Exchange(
     ),
     COINBASE(
         displayName = "Coinbase",
+        logoRes = R.drawable.ic_exchange_coinbase,
         supportedFiats = listOf("EUR", "USD", "GBP"),
         supportedCryptos = listOf("BTC", "ETH", "SOL", "ADA"),
         minOrderSize = mapOf("EUR" to BigDecimal("1"), "USD" to BigDecimal("1")),

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/CommonComponents.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/CommonComponents.kt
@@ -1,5 +1,7 @@
 package com.accbot.dca.presentation.components
 
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -14,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -128,11 +132,33 @@ fun PlanCard(
     }
 }
 
+@DrawableRes
+fun getCryptoIconRes(crypto: String): Int? = when (crypto.uppercase()) {
+    "BTC" -> R.drawable.ic_crypto_btc
+    "ETH" -> R.drawable.ic_crypto_eth
+    "SOL" -> R.drawable.ic_crypto_sol
+    "LTC" -> R.drawable.ic_crypto_ltc
+    "ADA" -> R.drawable.ic_crypto_ada
+    "DOT" -> R.drawable.ic_crypto_dot
+    else -> null
+}
+
+@DrawableRes
+fun getFiatIconRes(fiat: String): Int? = when (fiat.uppercase()) {
+    "EUR" -> R.drawable.ic_fiat_eur
+    "USD" -> R.drawable.ic_fiat_usd
+    "CZK" -> R.drawable.ic_fiat_czk
+    "GBP" -> R.drawable.ic_fiat_gbp
+    "USDT" -> R.drawable.ic_fiat_usdt
+    else -> null
+}
+
 @Composable
 fun CryptoIcon(
     crypto: String,
     size: Int = 48
 ) {
+    val iconRes = getCryptoIconRes(crypto)
     Box(
         modifier = Modifier
             .size(size.dp)
@@ -140,12 +166,21 @@ fun CryptoIcon(
             .background(MaterialTheme.colorScheme.surfaceVariant),
         contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = crypto.take(1),
-            fontWeight = FontWeight.Bold,
-            fontSize = (size / 2.4).sp,
-            color = successColor()
-        )
+        if (iconRes != null) {
+            Image(
+                painter = painterResource(iconRes),
+                contentDescription = crypto,
+                modifier = Modifier.size((size * 0.75f).dp),
+                contentScale = ContentScale.Fit
+            )
+        } else {
+            Text(
+                text = crypto.take(1),
+                fontWeight = FontWeight.Bold,
+                fontSize = (size / 2.4).sp,
+                color = successColor()
+            )
+        }
     }
 }
 
@@ -262,23 +297,11 @@ fun ExchangeCard(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(
-                            if (isConnected) successCol.copy(alpha = 0.15f)
-                            else MaterialTheme.colorScheme.surfaceVariant
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = exchange.displayName.first().toString(),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 20.sp,
-                        color = if (isConnected) successCol else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                ExchangeAvatar(
+                    exchange = exchange,
+                    size = 48.dp,
+                    isConnected = isConnected
+                )
                 Spacer(modifier = Modifier.width(12.dp))
                 Column {
                     Text(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/MainScaffold.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/MainScaffold.kt
@@ -1,7 +1,9 @@
 package com.accbot.dca.presentation.components
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
@@ -10,6 +12,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.accbot.dca.R
@@ -87,6 +91,7 @@ fun AccBotBottomNav(
 ) {
     val successCol = successColor()
     NavigationBar(
+        modifier = Modifier.height(56.dp),
         containerColor = MaterialTheme.colorScheme.surface,
         contentColor = MaterialTheme.colorScheme.onSurface
     ) {
@@ -112,13 +117,8 @@ fun AccBotBottomNav(
                 icon = {
                     Icon(
                         imageVector = if (isSelected) item.selectedIcon else item.unselectedIcon,
-                        contentDescription = stringResource(item.labelRes)
-                    )
-                },
-                label = {
-                    Text(
-                        text = stringResource(item.labelRes),
-                        style = MaterialTheme.typography.labelSmall
+                        contentDescription = stringResource(item.labelRes),
+                        modifier = Modifier.size(22.dp)
                     )
                 },
                 colors = NavigationBarItemDefaults.colors(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ReusableComponents.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ReusableComponents.kt
@@ -1,5 +1,6 @@
 package com.accbot.dca.presentation.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -14,6 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -44,6 +47,7 @@ fun SelectableChip(
     modifier: Modifier = Modifier,
     selectedColor: Color = successColor(),
     unselectedColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null
 ) {
     val backgroundColor = if (selected) selectedColor else unselectedColor
@@ -67,6 +71,7 @@ fun SelectableChip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
+            leadingIcon?.invoke()
             Text(
                 text = text,
                 color = contentColor,
@@ -100,7 +105,7 @@ fun IconBadge(
 }
 
 /**
- * Exchange avatar component displaying the first letter of the exchange name.
+ * Exchange avatar component displaying the exchange logo.
  * Reusable across exchange selection, exchange cards, and instructions screens.
  */
 @Composable
@@ -121,11 +126,11 @@ fun ExchangeAvatar(
             accentCol.copy(alpha = 0.15f)
         }
     ) {
-        Text(
-            text = exchange.displayName.first().toString(),
-            fontWeight = FontWeight.Bold,
-            fontSize = (size.value / 2.4).sp,
-            color = if (isConnected) successCol else accentCol
+        Image(
+            painter = painterResource(exchange.logoRes),
+            contentDescription = exchange.displayName,
+            modifier = Modifier.size(size * 0.6f),
+            contentScale = ContentScale.Fit
         )
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
@@ -27,6 +27,7 @@ import com.accbot.dca.R
 import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.DcaStrategy
 import com.accbot.dca.domain.util.CronUtils
+import com.accbot.dca.presentation.components.CryptoIcon
 import com.accbot.dca.presentation.ui.theme.Error
 import com.accbot.dca.presentation.ui.theme.Warning
 import com.accbot.dca.presentation.ui.theme.accentColor
@@ -160,7 +161,7 @@ fun DashboardScreen(
             }
 
             item {
-                Spacer(modifier = Modifier.height(80.dp))
+                Spacer(modifier = Modifier.height(56.dp))
             }
         }
     }
@@ -452,20 +453,7 @@ private fun DcaPlanCard(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.weight(1f)
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = plan.crypto.take(1),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 20.sp,
-                        color = successCol
-                    )
-                }
+                CryptoIcon(crypto = plan.crypto)
                 Spacer(modifier = Modifier.width(12.dp))
                 Column {
                     Text(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
@@ -1,6 +1,6 @@
 package com.accbot.dca.presentation.screens.onboarding
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -14,6 +14,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
@@ -327,25 +329,12 @@ private fun ExchangeGridItem(
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Exchange initial as icon placeholder
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(
-                        if (isSelected) successColor().copy(alpha = 0.2f)
-                        else MaterialTheme.colorScheme.surfaceVariant
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
-                val successCol = successColor()
-                Text(
-                    text = exchange.displayName.first().toString(),
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp,
-                    color = if (isSelected) successCol else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+            Image(
+                painter = painterResource(exchange.logoRes),
+                contentDescription = exchange.displayName,
+                modifier = Modifier.size(40.dp),
+                contentScale = ContentScale.Fit
+            )
 
             Spacer(modifier = Modifier.height(8.dp))
 

--- a/accbot-android/app/src/main/res/drawable/ic_crypto_ada.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_crypto_ada.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Cardano - Blue circle with A -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#0033AD"/>
+    <!-- A letter -->
+    <path
+        android:pathData="M46,86L64,36L82,86"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <!-- A crossbar -->
+    <path
+        android:pathData="M52,70L76,70"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_crypto_btc.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_crypto_btc.xml
@@ -1,0 +1,32 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Bitcoin - Orange circle with B symbol -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#F7931A"/>
+    <!-- Vertical bars -->
+    <path
+        android:pathData="M56,36L56,42M72,36L72,42M56,86L56,92M72,86L72,92"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- B shape -->
+    <path
+        android:pathData="M50,42L66,42C74,42 80,47 80,54C80,61 74,64 68,64L50,64L50,42Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M50,64L70,64C78,64 84,69 84,76C84,83 78,86 70,86L50,86L50,64Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_crypto_dot.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_crypto_dot.xml
@@ -1,0 +1,44 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Polkadot - Pink circle with dot pattern -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#E6007A"/>
+    <!-- Center dot -->
+    <path
+        android:pathData="M64,56A8,8 0,1 1,64,72A8,8 0,1 1,64,56z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Top dot -->
+    <path
+        android:pathData="M64,28A7,7 0,1 1,64,42A7,7 0,1 1,64,28z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.8"/>
+    <!-- Bottom dot -->
+    <path
+        android:pathData="M64,86A7,7 0,1 1,64,100A7,7 0,1 1,64,86z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.8"/>
+    <!-- Left dot -->
+    <path
+        android:pathData="M36,50A6,6 0,1 1,36,62A6,6 0,1 1,36,50z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.6"/>
+    <!-- Right dot -->
+    <path
+        android:pathData="M92,50A6,6 0,1 1,92,62A6,6 0,1 1,92,50z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.6"/>
+    <!-- Bottom-left dot -->
+    <path
+        android:pathData="M42,74A6,6 0,1 1,42,86A6,6 0,1 1,42,74z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.6"/>
+    <!-- Bottom-right dot -->
+    <path
+        android:pathData="M86,74A6,6 0,1 1,86,86A6,6 0,1 1,86,74z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.6"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_crypto_eth.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_crypto_eth.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Ethereum - Blue-purple circle with diamond shape -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#627EEA"/>
+    <!-- Diamond top -->
+    <path
+        android:pathData="M64,28L42,64L64,54L86,64Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.9"/>
+    <!-- Diamond bottom -->
+    <path
+        android:pathData="M64,100L42,64L64,74L86,64Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.6"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_crypto_ltc.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_crypto_ltc.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Litecoin - Silver-blue circle with L -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#345D9D"/>
+    <!-- L letter -->
+    <path
+        android:pathData="M54,36L54,86L82,86"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <!-- Slash through L -->
+    <path
+        android:pathData="M44,72L72,56"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"
+        android:fillAlpha="0.7"
+        android:strokeAlpha="0.7"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_crypto_sol.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_crypto_sol.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Solana - Purple circle with S -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#9945FF"/>
+    <!-- S letter -->
+    <path
+        android:pathData="M78,48C78,41 72,36 64,36C56,36 50,41 50,48C50,55 56,58 64,60C72,62 78,65 78,72C78,79 72,84 64,84C56,84 50,79 50,72"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_exchange_binance.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_exchange_binance.xml
@@ -1,0 +1,60 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Binance - Yellow/gold diamond logo on dark background -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#F3BA2F"/>
+    <!-- Central diamond -->
+    <path
+        android:pathData="M64,44 L74,54 L64,64 L54,54 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Top diamond -->
+    <path
+        android:pathData="M64,30 L70,36 L64,42 L58,36 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Bottom diamond -->
+    <path
+        android:pathData="M64,86 L70,92 L64,98 L58,92 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Left diamond -->
+    <path
+        android:pathData="M36,58 L42,64 L36,70 L30,64 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Right diamond -->
+    <path
+        android:pathData="M92,58 L98,64 L92,70 L86,64 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Top-left connector -->
+    <path
+        android:pathData="M48,48 L54,42 L58,46 L52,52 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Top-right connector -->
+    <path
+        android:pathData="M80,48 L74,42 L70,46 L76,52 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Bottom-left connector -->
+    <path
+        android:pathData="M48,80 L54,86 L58,82 L52,76 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Bottom-right connector -->
+    <path
+        android:pathData="M80,80 L74,86 L70,82 L76,76 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Left connectors -->
+    <path
+        android:pathData="M42,54 L48,48 L52,52 L46,58 Z"
+        android:fillColor="#FFFFFF"/>
+    <path
+        android:pathData="M42,74 L48,80 L52,76 L46,70 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Right connectors -->
+    <path
+        android:pathData="M86,54 L80,48 L76,52 L82,58 Z"
+        android:fillColor="#FFFFFF"/>
+    <path
+        android:pathData="M86,74 L80,80 L76,76 L82,70 Z"
+        android:fillColor="#FFFFFF"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_exchange_bitfinex.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_exchange_bitfinex.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Bitfinex - Green circle with triangular B shape -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#97C554"/>
+    <!-- Two triangles forming stylized logo -->
+    <path
+        android:pathData="M44,84 L64,36 L84,84 Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M52,72 L64,48 L76,72 Z"
+        android:fillColor="#FFFFFF"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_exchange_coinbase.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_exchange_coinbase.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Coinbase - Blue circle with C shape -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#0052FF"/>
+    <!-- Coinbase C mark -->
+    <path
+        android:pathData="M64,40 C50.7,40 40,50.7 40,64 C40,77.3 50.7,88 64,88 C71.5,88 78.2,84.6 82.7,79.3"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="8"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- Two horizontal lines (Coinbase logo detail) -->
+    <path
+        android:pathData="M68,56 L80,56"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="7"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M68,72 L80,72"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="7"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_exchange_coinmate.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_exchange_coinmate.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Coinmate - Blue circle with "CM" text style -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#1A73E8"/>
+    <!-- C letter -->
+    <path
+        android:pathData="M55,45 C48,45 43,50 43,58 C43,66 48,71 55,71 C59,71 62,69 64,66"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- M letter -->
+    <path
+        android:pathData="M68,71 L68,45 L76,58 L84,45 L84,71"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_exchange_huobi.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_exchange_huobi.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Huobi - Blue circle with flame/drop shape -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#2B3990"/>
+    <!-- Flame/water drop shape -->
+    <path
+        android:pathData="M64,32 C64,32 44,56 44,72 C44,83 53,92 64,92 C75,92 84,83 84,72 C84,56 64,32 64,32 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Inner drop -->
+    <path
+        android:pathData="M64,56 C64,56 54,68 54,75 C54,80.5 58.5,85 64,85 C69.5,85 74,80.5 74,75 C74,68 64,56 64,56 Z"
+        android:fillColor="#2B3990"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_exchange_kraken.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_exchange_kraken.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Kraken - Purple circle with K -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#5741D9"/>
+    <!-- K letter stylized -->
+    <path
+        android:pathData="M48,40 L48,88"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="8"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M48,64 L72,40"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="8"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M56,56 L80,88"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="8"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_exchange_kucoin.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_exchange_kucoin.xml
@@ -1,0 +1,35 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- KuCoin - Teal/green circle with geometric K shape -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#23AF91"/>
+    <!-- Vertical bar -->
+    <path
+        android:pathData="M46,40 L46,88"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="8"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- Center diamond -->
+    <path
+        android:pathData="M64,52 L76,64 L64,76 L52,64 Z"
+        android:fillColor="#FFFFFF"/>
+    <!-- Top-right arrow -->
+    <path
+        android:pathData="M68,56 L84,40"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="7"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- Bottom-right arrow -->
+    <path
+        android:pathData="M68,72 L84,88"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="7"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_fiat_czk.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_fiat_czk.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Czech Koruna - Blue circle with Kc -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#11457E"/>
+    <!-- K letter -->
+    <path
+        android:pathData="M42,36L42,86"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M42,62L62,36"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M42,62L62,86"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- c letter (smaller, lowercase) -->
+    <path
+        android:pathData="M84,58C81,55 78,54 74,54C68,54 64,59 64,66C64,73 68,78 74,78C78,78 81,77 84,74"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_fiat_eur.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_fiat_eur.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Euro - EU blue circle with euro sign -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#003399"/>
+    <!-- Euro C shape -->
+    <path
+        android:pathData="M82,44C77,37 70,34 62,34C50,34 40,44 40,58C40,72 50,82 62,82C70,82 77,79 82,72"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- Euro horizontal bars -->
+    <path
+        android:pathData="M36,54L68,54"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M36,66L68,66"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_fiat_gbp.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_fiat_gbp.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- British Pound - Purple circle with pound sign -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#4A235A"/>
+    <!-- Pound curve top -->
+    <path
+        android:pathData="M78,40C74,34 68,32 62,34C56,36 52,42 52,50L52,72C52,78 50,82 46,86L82,86"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <!-- Horizontal bar -->
+    <path
+        android:pathData="M42,62L72,62"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_fiat_usd.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_fiat_usd.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- US Dollar - Green circle with $ -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#2E7D32"/>
+    <!-- S shape -->
+    <path
+        android:pathData="M78,46C78,39 72,34 64,34C56,34 50,39 50,46C50,53 56,56 64,58C72,60 78,63 78,70C78,77 72,82 64,82C56,82 50,77 50,70"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- Vertical bar through $ -->
+    <path
+        android:pathData="M64,28L64,88"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/app/src/main/res/drawable/ic_fiat_usdt.xml
+++ b/accbot-android/app/src/main/res/drawable/ic_fiat_usdt.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <!-- Tether - Teal circle with T symbol -->
+    <path
+        android:pathData="M64,8A56,56 0,1 1,64,120A56,56 0,1 1,64,8z"
+        android:fillColor="#26A17B"/>
+    <!-- T horizontal bar -->
+    <path
+        android:pathData="M40,42L88,42"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+    <!-- T vertical bar -->
+    <path
+        android:pathData="M64,42L64,90"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/accbot-android/gradle.properties
+++ b/accbot-android/gradle.properties
@@ -9,4 +9,4 @@ android.nonTransitiveRClass=true
 # App versioning (semver)
 VERSION_MAJOR=2
 VERSION_MINOR=0
-VERSION_PATCH=113
+VERSION_PATCH=114


### PR DESCRIPTION
## Summary
- Add 18 vector drawable icons for crypto (BTC, ETH, SOL, LTC, ADA, DOT), exchanges (Coinmate, Binance, Kraken, KuCoin, Bitfinex, Huobi, Coinbase), and fiat currencies (USD, EUR, GBP, CZK, USDT)
- Exchange enum extended with `@DrawableRes logoRes` for type-safe icon references
- New `CryptoIcon`/`ExchangeAvatar` composables with drawable icon support
- 3-column grid layout for exchange selection (AddPlan + onboarding)
- Icon-only bottom navigation (56dp height, 22dp icons, no labels)
- Fix bottom nav visibility with prefix matching instead of exact route
- `SelectableChip` with `leadingIcon` support for crypto/fiat selection

## Test plan
- [ ] Verify all 18 icons render correctly on Dashboard, AddPlan, and onboarding screens
- [ ] Confirm bottom navigation shows correct active state with icon-only layout
- [ ] Test exchange grid selection in AddPlan and ExchangeSetup screens
- [ ] Verify crypto/fiat chips display icons in selection flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)