### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/accbot-android/gradle.properties
+++ b/accbot-android/gradle.properties
@@ -8,8 +8,8 @@ android.nonTransitiveRClass=true
 
 # App versioning (semver)
 VERSION_MAJOR=2
-VERSION_MINOR=0
-VERSION_PATCH=114
+VERSION_MINOR=1
+VERSION_PATCH=0
 
 # Screenshot testing
 android.experimental.enableScreenshotTest=true


### PR DESCRIPTION
## Summary
- Bump app version from 2.0.114 to 2.1.0 in `gradle.properties`
- Tag `v2.1.0` already pushed to trigger the release workflow

## Test plan
- [x] Tag `v2.1.0` pushed — GitHub Actions release workflow triggered
- [ ] Verify GitHub Actions build completes successfully
- [ ] Verify release appears at https://github.com/Crynners/AccBot/releases with APK + AAB artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)