### PR TITLE
Add auto-release-tag workflow

### DIFF
--- a/.github/workflows/auto-release-tag.yml
+++ b/.github/workflows/auto-release-tag.yml
@@ -1,0 +1,34 @@
+name: Auto-release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  create-tag:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          TAG="${BRANCH#release/}"
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Create and push tag
+        run: |
+          git tag ${{ steps.version.outputs.TAG }} ${{ github.event.pull_request.merge_commit_sha }}
+          git push origin ${{ steps.version.outputs.TAG }}


### PR DESCRIPTION
## Summary
- Adds a new workflow (`.github/workflows/auto-release-tag.yml`) that automatically creates a version tag when a `release/v*` branch is merged into `main`
- The pushed tag triggers the existing `android-release.yml` workflow, which builds and creates the GitHub Release with APK/AAB artifacts
- Eliminates the need to manually create and push tags after merging release PRs

## How it works
1. PR with source branch matching `release/v*` is merged into `main`
2. `auto-release-tag.yml` extracts the version (e.g. `release/v2.1.1` → `v2.1.1`)
3. Tag is created on the merge commit and pushed
4. `android-release.yml` picks up the new tag and runs the build + release

## Test plan
- [x] Tag `v2.1.1` pushed manually to verify existing `android-release.yml` works
- [ ] Verify next release (`release/v*` → main merge) auto-creates the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)