### PR TITLE
Fix versionCode formula to prevent Play Store rejection

### DIFF
--- a/accbot-android/app/build.gradle.kts
+++ b/accbot-android/app/build.gradle.kts
@@ -37,7 +37,7 @@ android {
         applicationId = "com.accbot.dca"
         minSdk = 26
         targetSdk = 36
-        versionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
+        versionCode = versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100
         versionName = "$versionMajor.$versionMinor.$versionPatch"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary
- Fix versionCode formula from `MAJOR*10000 + MINOR*100 + PATCH` to `MAJOR*10000 + MINOR*1000 + PATCH*100`
- The old formula allowed PATCH overflow past 99, causing v2.1.1 (code 20101) to be lower than v2.0.114 (code 20114), which Google Play rejects
- New formula gives v2.1.1 → code 21100

## After merge
Tag `v2.1.1` needs to be created on the merge commit to trigger the `android-release.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)