### PR TITLE
Fix dashboard refresh, data consistency and UX improvements

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/MainActivity.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/MainActivity.kt
@@ -314,7 +314,11 @@ fun AccBotApp(
         composable(Screen.AddPlan.route) {
             AddPlanScreen(
                 onNavigateBack = { navController.popBackStack() },
-                onPlanCreated = { navController.popBackStack() }
+                onPlanCreated = { navController.popBackStack() },
+                onNavigateToExchangeDetail = { exchangeName ->
+                    navController.popBackStack()
+                    navController.navigate(Screen.ExchangeDetail.createRoute(exchangeName, autoImport = true))
+                }
             )
         }
 
@@ -388,7 +392,8 @@ fun AccBotApp(
         composable(
             route = Screen.ExchangeDetail.route,
             arguments = listOf(
-                navArgument(Screen.EXCHANGE_ARG) { type = NavType.StringType }
+                navArgument(Screen.EXCHANGE_ARG) { type = NavType.StringType },
+                navArgument("autoImport") { type = NavType.BoolType; defaultValue = false }
             )
         ) {
             ExchangeDetailScreen(
@@ -406,7 +411,11 @@ fun AccBotApp(
         ) {
             AddExchangeScreen(
                 onNavigateBack = { navController.popBackStack() },
-                onExchangeAdded = { navController.popBackStack() }
+                onExchangeAdded = { navController.popBackStack() },
+                onNavigateToExchangeDetail = { exchangeName ->
+                    navController.popBackStack()
+                    navController.navigate(Screen.ExchangeDetail.createRoute(exchangeName, autoImport = true))
+                }
             )
         }
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/Daos.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/Daos.kt
@@ -47,6 +47,9 @@ interface DcaPlanDao {
     @Query("DELETE FROM dca_plans")
     suspend fun deleteAllPlans()
 
+    @Query("DELETE FROM dca_plans WHERE exchange = :exchange")
+    suspend fun deletePlansByExchange(exchange: Exchange)
+
     @Query("SELECT COUNT(*) FROM dca_plans")
     suspend fun getPlanCount(): Int
 }
@@ -207,6 +210,9 @@ interface TransactionDao {
 
     @Query("DELETE FROM transactions WHERE planId = :planId")
     suspend fun deleteTransactionsByPlanId(planId: Long)
+
+    @Query("DELETE FROM transactions WHERE exchange = :exchange")
+    suspend fun deleteTransactionsByExchange(exchange: Exchange)
 
     @Query("""
         SELECT crypto || '/' || fiat as pair, crypto, fiat,

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/Daos.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/Daos.kt
@@ -288,6 +288,9 @@ interface WithdrawalDao {
 
     @Delete
     suspend fun deleteWithdrawal(withdrawal: WithdrawalEntity)
+
+    @Query("DELETE FROM withdrawals")
+    suspend fun deleteAllWithdrawals()
 }
 
 @Dao
@@ -350,6 +353,9 @@ interface DailyPriceDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPrices(prices: List<DailyPriceEntity>)
+
+    @Query("DELETE FROM daily_prices")
+    suspend fun deleteAllPrices()
 }
 
 @Dao

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/navigation/Screen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/navigation/Screen.kt
@@ -32,8 +32,11 @@ sealed class Screen(val route: String) {
 
     // Exchange screens
     data object ExchangeManagement : Screen("exchanges/manage")
-    data object ExchangeDetail : Screen("exchanges/detail/{exchange}") {
-        fun createRoute(exchangeName: String) = "exchanges/detail/$exchangeName"
+    data object ExchangeDetail : Screen("exchanges/detail/{exchange}?autoImport={autoImport}") {
+        fun createRoute(exchangeName: String, autoImport: Boolean = false): String {
+            return if (autoImport) "exchanges/detail/$exchangeName?autoImport=true"
+            else "exchanges/detail/$exchangeName"
+        }
     }
     data object AddExchange : Screen("exchanges/add?exchange={exchange}") {
         fun createRoute(exchangeName: String? = null): String {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
@@ -45,6 +45,7 @@ import com.accbot.dca.presentation.ui.theme.successColor
 fun AddPlanScreen(
     onNavigateBack: () -> Unit,
     onPlanCreated: () -> Unit,
+    onNavigateToExchangeDetail: ((String) -> Unit)? = null,
     viewModel: AddPlanViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -53,6 +54,31 @@ fun AddPlanScreen(
         if (uiState.isSuccess) {
             onPlanCreated()
         }
+    }
+
+    // Import offer dialog after creating plan with new credentials
+    if (uiState.showImportDialog) {
+        val exchangeName = uiState.selectedExchange?.displayName ?: ""
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissImportDialog() },
+            title = { Text(stringResource(R.string.import_api_offer_title)) },
+            text = { Text(stringResource(R.string.import_api_offer_text, exchangeName)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.dismissImportDialog()
+                    uiState.selectedExchange?.let { exchange ->
+                        onNavigateToExchangeDetail?.invoke(exchange.name)
+                    }
+                }) {
+                    Text(stringResource(R.string.import_api_title))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissImportDialog() }) {
+                    Text(stringResource(R.string.common_skip))
+                }
+            }
+        )
     }
 
     Scaffold(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanViewModel.kt
@@ -9,6 +9,7 @@ import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.DcaStrategy
 import com.accbot.dca.domain.model.Exchange
+import com.accbot.dca.domain.model.supportsApiImport
 import com.accbot.dca.domain.util.CronUtils
 import com.accbot.dca.presentation.model.MonthlyCostEstimate
 import com.accbot.dca.domain.model.ExchangeFilter
@@ -55,6 +56,7 @@ data class AddPlanUiState(
     val withdrawalAddress: String = "",
     val isLoading: Boolean = false,
     val isSuccess: Boolean = false,
+    val showImportDialog: Boolean = false,
     val errorMessage: String? = null,
     val monthlyCostEstimate: MonthlyCostEstimate? = null,
     val minOrderSize: BigDecimal? = null
@@ -301,7 +303,12 @@ class AddPlanViewModel @Inject constructor(
 
                 dcaPlanDao.insertPlan(plan)
 
-                _uiState.update { it.copy(isLoading = false, isSuccess = true) }
+                val shouldOfferImport = !state.hasCredentials && exchange.supportsApiImport
+                _uiState.update { it.copy(
+                    isLoading = false,
+                    isSuccess = !shouldOfferImport,
+                    showImportDialog = shouldOfferImport
+                ) }
             } catch (e: Exception) {
                 _uiState.update {
                     it.copy(
@@ -311,5 +318,9 @@ class AddPlanViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun dismissImportDialog() {
+        _uiState.update { it.copy(showImportDialog = false, isSuccess = true) }
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
@@ -74,14 +74,7 @@ fun DashboardScreen(
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
-    // Ticker to force recomposition of "Next:" time every 60s
-    var refreshTick by remember { mutableIntStateOf(0) }
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(60_000L)
-            refreshTick++
-        }
-    }
+    // Ticker moved into DcaPlanCard – see currentTime state there
 
     LaunchedEffect(uiState.runNowTriggered) {
         if (uiState.runNowTriggered) {
@@ -186,7 +179,7 @@ fun DashboardScreen(
                                 planWithBalance = planWithBalance,
                                 onToggle = { viewModel.togglePlan(planWithBalance.plan.id) },
                                 onClick = { onNavigateToPlanDetails?.invoke(planWithBalance.plan.id) },
-                                refreshTick = refreshTick
+
                             )
                         }
                     }
@@ -255,8 +248,7 @@ fun DashboardScreen(
                         DcaPlanCard(
                             planWithBalance = planWithBalance,
                             onToggle = { viewModel.togglePlan(planWithBalance.plan.id) },
-                            onClick = { onNavigateToPlanDetails?.invoke(planWithBalance.plan.id) },
-                            refreshTick = refreshTick
+                            onClick = { onNavigateToPlanDetails?.invoke(planWithBalance.plan.id) }
                         )
                     }
                 }
@@ -671,14 +663,21 @@ internal fun StatItem(label: String, value: String) {
 internal fun DcaPlanCard(
     planWithBalance: DcaPlanWithBalance,
     onToggle: () -> Unit,
-    onClick: (() -> Unit)? = null,
-    @Suppress("UNUSED_PARAMETER") // Changing value forces recomposition → refreshes relative "Next:" time
-    refreshTick: Int = 0
+    onClick: (() -> Unit)? = null
 ) {
     val plan = planWithBalance.plan
     val successCol = successColor()
     val accentCol = accentColor()
     val context = LocalContext.current
+
+    // Self-contained ticker: updates currentTime every 60s so the countdown text refreshes
+    var currentTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(60_000L)
+            currentTime = System.currentTimeMillis()
+        }
+    }
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -749,6 +748,8 @@ internal fun DcaPlanCard(
                                 modifier = Modifier.size(12.dp),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                            @Suppress("UNUSED_EXPRESSION")
+                            currentTime // read state so Compose tracks it as a dependency
                             Text(
                                 text = stringResource(R.string.dashboard_next_prefix, TimeUtils.formatTimeUntil(plan.nextExecutionAt, context)),
                                 style = MaterialTheme.typography.bodySmall,

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardViewModel.kt
@@ -22,9 +22,11 @@ import com.accbot.dca.worker.DcaWorker
 import androidx.compose.runtime.Immutable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.coroutineContext
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
@@ -185,6 +187,7 @@ class DashboardViewModel @Inject constructor(
                 holding
             }
         }
+        coroutineContext.ensureActive()
         _uiState.update { it.copy(holdings = updatedHoldings, isPriceLoading = false) }
     }
 
@@ -275,7 +278,14 @@ class DashboardViewModel @Inject constructor(
             }
         }
 
-        _uiState.update { it.copy(activePlans = plansWithBalance) }
+        // Guard: only update if the plan set hasn't changed (prevents stale
+        // data from a cancelled collectLatest block overwriting fresh data)
+        coroutineContext.ensureActive()
+        _uiState.update { current ->
+            val currentIds = current.activePlans.map { it.plan.id }.toSet()
+            val fetchedIds = plansWithBalance.map { it.plan.id }.toSet()
+            if (currentIds == fetchedIds) current.copy(activePlans = plansWithBalance) else current
+        }
     }
 
     fun refreshPrices() {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsScreen.kt
@@ -64,12 +64,12 @@ fun SettingsScreen(
     var showDeleteNotificationsDialog by rememberSaveable { mutableStateOf(false) }
     var dangerZoneExpanded by rememberSaveable { mutableStateOf(false) }
 
-    // Refresh battery status when returning from system settings
+    // Refresh non-reactive data (battery, exchange count, data counts) when returning
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.refreshBatteryStatus()
+                viewModel.refresh()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
@@ -6,14 +6,16 @@ import android.content.Intent
 import android.os.PowerManager
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.accbot.dca.data.local.DcaDatabase
 import com.accbot.dca.data.local.CredentialsStore
+import com.accbot.dca.data.local.DailyPriceDao
 import com.accbot.dca.data.local.DcaPlanDao
 import com.accbot.dca.data.local.ExchangeBalanceDao
+import com.accbot.dca.data.local.MonthlySummaryDao
 import com.accbot.dca.data.local.NotificationDao
 import com.accbot.dca.data.local.OnboardingPreferences
 import com.accbot.dca.data.local.TransactionDao
 import com.accbot.dca.data.local.UserPreferences
+import com.accbot.dca.data.local.WithdrawalDao
 import com.accbot.dca.data.local.WithdrawalThresholdDao
 import com.accbot.dca.data.local.WithdrawalThresholdEntity
 import com.accbot.dca.data.local.toDomain
@@ -53,10 +55,13 @@ class SettingsViewModel @Inject constructor(
     private val credentialsStore: CredentialsStore,
     private val onboardingPreferences: OnboardingPreferences,
     private val userPreferences: UserPreferences,
-    private val database: DcaDatabase,
     private val dcaPlanDao: DcaPlanDao,
     private val transactionDao: TransactionDao,
     private val notificationDao: NotificationDao,
+    private val exchangeBalanceDao: ExchangeBalanceDao,
+    private val monthlySummaryDao: MonthlySummaryDao,
+    private val dailyPriceDao: DailyPriceDao,
+    private val withdrawalDao: WithdrawalDao,
     private val withdrawalThresholdDao: WithdrawalThresholdDao
 ) : AndroidViewModel(application) {
 
@@ -255,11 +260,19 @@ class SettingsViewModel @Inject constructor(
                 // Reset sandbox mode to default (off)
                 userPreferences.setSandboxMode(false)
 
-                // Clear database
-                database.clearAllTables()
+                // Clear all database tables using suspend DAO methods
+                // (Room runs these on its IO executor, unlike clearAllTables()
+                // which is a blocking call that can fail on the main thread)
+                dcaPlanDao.deleteAllPlans()
+                transactionDao.deleteAllTransactions()
+                notificationDao.deleteAllNotifications()
+                exchangeBalanceDao.deleteAllBalances()
+                monthlySummaryDao.deleteAllSummaries()
+                dailyPriceDao.deleteAllPrices()
+                withdrawalDao.deleteAllWithdrawals()
+                withdrawalThresholdDao.deleteAll()
 
-                // Restart app to avoid Flow race condition (Room Flows actively
-                // collecting while clearAllTables() invalidates tables)
+                // Restart app to apply clean state
                 restartApp(application)
             } finally {
                 isDeleting = false

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
@@ -75,6 +75,12 @@ class SettingsViewModel @Inject constructor(
         loadDataCounts()
     }
 
+    /** Re-read non-reactive data (credentials, battery, counts). Called on ON_RESUME. */
+    fun refresh() {
+        loadSettings()
+        loadDataCounts()
+    }
+
     private fun loadSettings() {
         val isSandbox = userPreferences.isSandboxMode()
         val configuredExchanges = credentialsStore.getConfiguredExchanges(isSandbox)

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
@@ -47,10 +47,36 @@ import com.accbot.dca.presentation.ui.theme.successColor
 fun AddExchangeScreen(
     onNavigateBack: () -> Unit,
     onExchangeAdded: () -> Unit,
+    onNavigateToExchangeDetail: ((String) -> Unit)? = null,
     viewModel: AddExchangeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
+
+    // Import offer dialog after successful exchange connection
+    if (uiState.showImportOffer) {
+        val exchangeName = uiState.selectedExchange?.displayName ?: ""
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissImportOffer() },
+            title = { Text(stringResource(R.string.import_api_offer_title)) },
+            text = { Text(stringResource(R.string.import_api_offer_text, exchangeName)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.dismissImportOffer()
+                    uiState.selectedExchange?.let { exchange ->
+                        onNavigateToExchangeDetail?.invoke(exchange.name)
+                    }
+                }) {
+                    Text(stringResource(R.string.import_api_title))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissImportOffer() }) {
+                    Text(stringResource(R.string.common_skip))
+                }
+            }
+        )
+    }
 
     Scaffold(
         topBar = {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeViewModel.kt
@@ -14,6 +14,7 @@ import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.ExchangeInstructions
 import com.accbot.dca.domain.model.ExchangeInstructionsProvider
+import com.accbot.dca.domain.model.supportsApiImport
 import com.accbot.dca.domain.model.supportsSandbox
 import com.accbot.dca.domain.usecase.ApiImportProgress
 import com.accbot.dca.domain.usecase.ApiImportResultState
@@ -55,6 +56,7 @@ data class AddExchangeUiState(
     val error: String? = null,
     val isSandboxMode: Boolean = false,
     val plansForExchange: List<DcaPlanEntity> = emptyList(),
+    val showImportOffer: Boolean = false,
     val isApiImporting: Boolean = false,
     val apiImportProgress: String = "",
     val apiImportResult: ApiImportResultState? = null
@@ -152,6 +154,7 @@ class AddExchangeViewModel @Inject constructor(
                         it.copy(
                             isValidating = false,
                             isSuccess = true,
+                            showImportOffer = exchange.supportsApiImport,
                             currentStep = ExchangeSetupStep.SUCCESS
                         )
                     }
@@ -254,6 +257,10 @@ class AddExchangeViewModel @Inject constructor(
 
     fun dismissImportResult() {
         _uiState.update { it.copy(apiImportResult = null) }
+    }
+
+    fun dismissImportOffer() {
+        _uiState.update { it.copy(showImportOffer = false) }
     }
 
     /**

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailScreen.kt
@@ -81,11 +81,18 @@ fun ExchangeDetailScreen(
 
     // Remove confirmation dialog
     if (showRemoveDialog) {
+        val planCount = uiState.plans.size
         AlertDialog(
             onDismissRequest = { showRemoveDialog = false },
             title = { Text(stringResource(R.string.exchanges_remove_title)) },
             text = {
-                Text(stringResource(R.string.exchanges_remove_text, exchange.displayName))
+                Text(
+                    if (planCount > 0) {
+                        stringResource(R.string.exchanges_remove_text_with_plans, exchange.displayName, planCount)
+                    } else {
+                        stringResource(R.string.exchanges_remove_text, exchange.displayName)
+                    }
+                )
             },
             confirmButton = {
                 TextButton(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.accbot.dca.data.local.CredentialsStore
 import com.accbot.dca.data.local.DcaPlanDao
 import com.accbot.dca.data.local.DcaPlanEntity
+import com.accbot.dca.data.local.TransactionDao
 import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.usecase.ApiImportProgress
@@ -47,6 +48,7 @@ class ExchangeDetailViewModel @Inject constructor(
     private val userPreferences: UserPreferences,
     private val validateAndSaveCredentialsUseCase: ValidateAndSaveCredentialsUseCase,
     private val dcaPlanDao: DcaPlanDao,
+    private val transactionDao: TransactionDao,
     private val importTradeHistoryUseCase: ImportTradeHistoryUseCase,
     private val exchangeApiFactory: ExchangeApiFactory,
     savedStateHandle: SavedStateHandle
@@ -58,6 +60,7 @@ class ExchangeDetailViewModel @Inject constructor(
     init {
         val isSandbox = userPreferences.isSandboxMode()
         val exchangeName = savedStateHandle.get<String>("exchange")
+        val autoImport = savedStateHandle.get<Boolean>("autoImport") ?: false
         val exchange = exchangeName?.let { name ->
             Exchange.entries.find { it.name == name }
         }
@@ -76,9 +79,15 @@ class ExchangeDetailViewModel @Inject constructor(
             }
 
             // Load plans for this exchange
+            var autoImportTriggered = false
             viewModelScope.launch {
                 dcaPlanDao.getPlansByExchange(exchange).collect { plans ->
                     _uiState.update { it.copy(plans = plans) }
+                    // Auto-trigger import when navigated from import offer dialog
+                    if (autoImport && !autoImportTriggered && plans.isNotEmpty()) {
+                        autoImportTriggered = true
+                        importViaApi()
+                    }
                 }
             }
         }
@@ -224,8 +233,13 @@ class ExchangeDetailViewModel @Inject constructor(
     fun removeExchange(onRemoved: () -> Unit) {
         val state = _uiState.value
         val exchange = state.exchange ?: return
-        credentialsStore.deleteCredentials(exchange, state.isSandboxMode)
-        onRemoved()
+        viewModelScope.launch {
+            // Delete transactions, plans and credentials for this exchange
+            transactionDao.deleteTransactionsByExchange(exchange)
+            dcaPlanDao.deletePlansByExchange(exchange)
+            credentialsStore.deleteCredentials(exchange, state.isSandboxMode)
+            onRemoved()
+        }
     }
 
     companion object {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,9 +39,16 @@ fun ExchangeManagementScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    // Refresh when returning to screen
-    LaunchedEffect(Unit) {
-        viewModel.loadConnectedExchanges()
+    // Refresh when returning to screen (e.g. after removing exchange in detail)
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.loadConnectedExchanges()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     Scaffold(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/OnboardingViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/OnboardingViewModel.kt
@@ -75,11 +75,22 @@ class OnboardingViewModel @Inject constructor(
     init {
         // Initialize sandbox state once - avoids repeated calls during recomposition
         val isSandbox = userPreferences.isSandboxMode()
+        // Detect already-configured exchange (e.g. credentials saved on ExchangeSetupScreen).
+        // hiltViewModel() creates a separate instance per NavBackStackEntry, so FirstPlanScreen
+        // needs to restore the selected exchange from persisted credentials.
+        val configured = credentialsStore.getConfiguredExchanges(isSandbox).firstOrNull()
         _uiState.update {
             it.copy(
                 isSandboxMode = isSandbox,
-                availableExchanges = ExchangeFilter.getAvailableExchanges(isSandbox)
+                availableExchanges = ExchangeFilter.getAvailableExchanges(isSandbox),
+                selectedExchange = configured,
+                selectedCrypto = configured?.supportedCryptos?.firstOrNull() ?: "BTC",
+                selectedFiat = configured?.supportedFiats?.firstOrNull() ?: "EUR",
+                credentialsValid = configured != null
             )
+        }
+        if (configured != null) {
+            updateMinOrderSize()
         }
     }
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/portfolio/PortfolioScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/portfolio/PortfolioScreen.kt
@@ -21,6 +21,9 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,6 +67,18 @@ fun PortfolioScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    // Refresh portfolio data when returning to screen (e.g. after transaction import)
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refresh()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // Landscape: two-pane layout — chart left, controls right
     if (isLandscape) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/utils/TimeUtils.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/utils/TimeUtils.kt
@@ -14,11 +14,21 @@ object TimeUtils {
         return when {
             duration.toHours() >= 24 -> {
                 val days = duration.toDays()
-                if (days == 1L) context.getString(R.string.time_in_1_day) else context.getString(R.string.time_in_days, days.toInt())
+                val remainingHours = (duration.toHours() % 24).toInt()
+                if (remainingHours == 0) {
+                    if (days == 1L) context.getString(R.string.time_in_1_day_exact) else context.getString(R.string.time_in_days_exact, days.toInt())
+                } else {
+                    if (days == 1L) context.getString(R.string.time_in_1_day, remainingHours) else context.getString(R.string.time_in_days, days.toInt(), remainingHours)
+                }
             }
             duration.toHours() >= 1 -> {
                 val hours = duration.toHours()
-                if (hours == 1L) context.getString(R.string.time_in_1_hour) else context.getString(R.string.time_in_hours, hours.toInt())
+                val remainingMinutes = (duration.toMinutes() % 60).toInt()
+                if (remainingMinutes == 0) {
+                    if (hours == 1L) context.getString(R.string.time_in_1_hour_exact) else context.getString(R.string.time_in_hours_exact, hours.toInt())
+                } else {
+                    if (hours == 1L) context.getString(R.string.time_in_1_hour, remainingMinutes) else context.getString(R.string.time_in_hours, hours.toInt(), remainingMinutes)
+                }
             }
             else -> {
                 val minutes = duration.toMinutes()

--- a/accbot-android/app/src/main/java/com/accbot/dca/service/NotificationService.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/service/NotificationService.kt
@@ -109,6 +109,7 @@ class NotificationService @Inject constructor(
         cryptoAmount: BigDecimal,
         fiatAmount: BigDecimal,
         fiat: String,
+        price: BigDecimal,
         planId: Long = 0,
         pending: Boolean = false,
         exchange: Exchange? = null
@@ -120,10 +121,11 @@ class NotificationService @Inject constructor(
         )
 
         val title = context.getString(R.string.notification_purchase_title)
+        val priceFormatted = price.stripTrailingZeros().toPlainString()
         val text = if (pending) {
-            context.getString(R.string.notification_purchase_pending_text, fiatAmount.toPlainString(), fiat, crypto)
+            context.getString(R.string.notification_purchase_pending_text, fiatAmount.toPlainString(), fiat, crypto, priceFormatted)
         } else {
-            context.getString(R.string.notification_purchase_text, cryptoAmount.toPlainString(), crypto, fiatAmount.toPlainString(), fiat)
+            context.getString(R.string.notification_purchase_text, cryptoAmount.toPlainString(), crypto, fiatAmount.toPlainString(), fiat, priceFormatted)
         }
 
         val notification = NotificationCompat.Builder(context, CHANNEL_PURCHASE)

--- a/accbot-android/app/src/main/java/com/accbot/dca/worker/DcaWorker.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/worker/DcaWorker.kt
@@ -206,6 +206,7 @@ class DcaWorker @AssistedInject constructor(
                             finalResult.transaction.cryptoAmount,
                             if (isPending) purchaseAmount else finalResult.transaction.fiatAmount,
                             plan.fiat,
+                            finalResult.transaction.price,
                             plan.id,
                             pending = isPending,
                             exchange = plan.exchange

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -263,7 +263,8 @@
     <string name="exchanges_connected">Připojené burzy</string>
     <string name="exchanges_available">Dostupné burzy</string>
     <string name="exchanges_remove_title">Odebrat burzu</string>
-    <string name="exchanges_remove_text">Opravdu chcete odebrat %1$s? Tím se smažou vaše API přihlašovací údaje z tohoto zařízení.</string>
+    <string name="exchanges_remove_text">Opravdu chcete odebrat %1$s? Tím se smaže veškerá historie transakcí a API přihlašovací údaje pro tuto burzu.</string>
+    <string name="exchanges_remove_text_with_plans">Opravdu chcete odebrat %1$s? Tato burza má %2$d aktivní(ch) DCA plán(ů). Odebrání burzy smaže všechny přidružené DCA plány, historii transakcí a API přihlašovací údaje.</string>
     <string name="exchanges_none_title">Žádné dostupné burzy</string>
     <string name="exchanges_none_desc">Nejsou k dispozici žádné burzy</string>
     <string name="exchanges_detail_cryptos">Kryptoměny</string>
@@ -449,8 +450,8 @@
     <string name="notification_service_title">AccBot DCA aktivní</string>
     <string name="notification_service_text">Sledování vašich DCA plánů</string>
     <string name="notification_purchase_title">DCA nákup dokončen ✓</string>
-    <string name="notification_purchase_text">Nakoupeno %1$s %2$s za %3$s %4$s</string>
-    <string name="notification_purchase_pending_text">Nakoupeno ~%1$s %2$s za %3$s (potvrzování…)</string>
+    <string name="notification_purchase_text">Nakoupeno %1$s %2$s za %3$s %4$s @ %5$s %4$s</string>
+    <string name="notification_purchase_pending_text">Nakoupeno ~%1$s %2$s za %3$s @ %4$s %2$s (potvrzování…)</string>
     <string name="notification_dca_failed">DCA selhalo</string>
     <string name="notification_dca_failed_text">Nepodařilo se nakoupit %1$s: %2$s</string>
     <string name="notification_dca_error">DCA chyba</string>
@@ -547,6 +548,8 @@
     <string name="import_api_error_title">Import selhal</string>
     <string name="import_api_success_message">%1$d transakcí importováno, %2$d přeskočeno (již existovaly)</string>
     <string name="import_api_no_new">Žádné nové transakce k importu</string>
+    <string name="import_api_offer_title">Importovat historii transakcí?</string>
+    <string name="import_api_offer_text">Chcete importovat existující historii transakcí z %1$s? Můžete to udělat i později v detailu burzy.</string>
 
     <!-- Schedule Builder -->
     <string name="schedule_type_label">Typ rozvrhu</string>

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -462,10 +462,14 @@
     <!-- TimeUtils -->
     <string name="time_not_scheduled">Nenaplánováno</string>
     <string name="time_due_now">Právě teď</string>
-    <string name="time_in_days">za %1$d dní</string>
-    <string name="time_in_1_day">za 1 den</string>
-    <string name="time_in_hours">za %1$d hodin</string>
-    <string name="time_in_1_hour">za 1 hodinu</string>
+    <string name="time_in_days">za %1$d dní %2$d h</string>
+    <string name="time_in_1_day">za 1 den %1$d h</string>
+    <string name="time_in_days_exact">za %1$d dní</string>
+    <string name="time_in_1_day_exact">za 1 den</string>
+    <string name="time_in_hours">za %1$d h %2$d min</string>
+    <string name="time_in_1_hour">za 1 h %1$d min</string>
+    <string name="time_in_hours_exact">za %1$d h</string>
+    <string name="time_in_1_hour_exact">za 1 h</string>
     <string name="time_in_minutes">za %1$d min</string>
     <string name="time_in_less_1_min">za &lt; 1 min</string>
 

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -461,10 +461,14 @@
     <!-- TimeUtils -->
     <string name="time_not_scheduled">Not scheduled</string>
     <string name="time_due_now">Due now</string>
-    <string name="time_in_days">in %1$d days</string>
-    <string name="time_in_1_day">in 1 day</string>
-    <string name="time_in_hours">in %1$d hours</string>
-    <string name="time_in_1_hour">in 1 hour</string>
+    <string name="time_in_days">in %1$d days %2$d h</string>
+    <string name="time_in_1_day">in 1 day %1$d h</string>
+    <string name="time_in_days_exact">in %1$d days</string>
+    <string name="time_in_1_day_exact">in 1 day</string>
+    <string name="time_in_hours">in %1$d h %2$d min</string>
+    <string name="time_in_1_hour">in 1 h %1$d min</string>
+    <string name="time_in_hours_exact">in %1$d h</string>
+    <string name="time_in_1_hour_exact">in 1 h</string>
     <string name="time_in_minutes">in %1$d min</string>
     <string name="time_in_less_1_min">in &lt; 1 min</string>
 

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -262,7 +262,8 @@
     <string name="exchanges_connected">Connected Exchanges</string>
     <string name="exchanges_available">Available Exchanges</string>
     <string name="exchanges_remove_title">Remove Exchange</string>
-    <string name="exchanges_remove_text">Are you sure you want to remove %1$s? This will delete your API credentials from this device.</string>
+    <string name="exchanges_remove_text">Are you sure you want to remove %1$s? This will delete all transaction history and API credentials for this exchange.</string>
+    <string name="exchanges_remove_text_with_plans">Are you sure you want to remove %1$s? This exchange has %2$d active DCA plan(s). Removing the exchange will delete all associated DCA plans, transaction history and API credentials.</string>
     <string name="exchanges_none_title">No Exchanges Available</string>
     <string name="exchanges_none_desc">There are no exchanges to display</string>
     <string name="exchanges_detail_cryptos">Cryptocurrencies</string>
@@ -448,8 +449,8 @@
     <string name="notification_service_title">AccBot DCA Active</string>
     <string name="notification_service_text">Monitoring your DCA plans</string>
     <string name="notification_purchase_title">DCA Purchase Completed ✓</string>
-    <string name="notification_purchase_text">Bought %1$s %2$s for %3$s %4$s</string>
-    <string name="notification_purchase_pending_text">Purchased ~%1$s %2$s of %3$s (confirming…)</string>
+    <string name="notification_purchase_text">Bought %1$s %2$s for %3$s %4$s @ %5$s %4$s</string>
+    <string name="notification_purchase_pending_text">Purchased ~%1$s %2$s of %3$s @ %4$s %2$s (confirming…)</string>
     <string name="notification_dca_failed">DCA Failed</string>
     <string name="notification_dca_failed_text">Failed to buy %1$s: %2$s</string>
     <string name="notification_dca_error">DCA Error</string>
@@ -567,6 +568,8 @@
     <string name="import_api_error_title">Import Failed</string>
     <string name="import_api_success_message">%1$d transactions imported, %2$d skipped (already existed)</string>
     <string name="import_api_no_new">No new transactions to import</string>
+    <string name="import_api_offer_title">Import Transaction History?</string>
+    <string name="import_api_offer_text">Would you like to import your existing transaction history from %1$s? You can also do this later from the exchange detail screen.</string>
 
     <!-- Exchange Instructions - Coinmate -->
     <string name="exchange_instructions_coinmate_1">Go to coinmate.io and log in</string>


### PR DESCRIPTION
## Summary
- **Dashboard countdown refresh**: Fix DCA plan countdown timer not updating visually (moved ticker into DcaPlanCard, refined time formatting)
- **Delete all data**: Fix `clearAllTables()` failing on main thread — use explicit suspend DAO methods instead
- **Exchange removal**: Delete associated transactions + plans when removing exchange, with warning dialog
- **Import offer**: Offer transaction import after connecting a new exchange, auto-trigger import via nav argument
- **Stale data fixes**: Refresh Settings, ExchangeManagement, Portfolio and Dashboard on lifecycle resume
- **Dashboard race condition**: Prevent `fetchBalancesForPlans` from overwriting `activePlans` with stale data after plan deletion
- **Onboarding bug**: Fix FirstPlanScreen showing "no exchange connected" by restoring configured exchange from CredentialsStore
- **Notification price**: Show purchase price in buy notifications

## Test plan
- [ ] Fresh install → onboarding → connect exchange → create plan → verify no "no exchange" error
- [ ] After connecting exchange, verify import offer dialog appears and auto-triggers import
- [ ] Remove exchange → verify plans, transactions and credentials are all deleted
- [ ] Remove exchange → verify Settings shows updated exchange count
- [ ] Delete a DCA plan → verify card disappears from dashboard immediately
- [ ] Import transactions → switch to Portfolio tab → verify data is refreshed
- [ ] Verify countdown timer on dashboard updates every 60s without tab switching
- [ ] Settings → Delete all data → verify everything is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)