### PR TITLE
Fix auto-release tag + rename app to AccBot DCA

### DIFF
--- a/.github/workflows/auto-release-tag.yml
+++ b/.github/workflows/auto-release-tag.yml
@@ -11,8 +11,6 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Extract version from branch name
@@ -27,6 +25,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.PAT_GITHUB }}
 
       - name: Create and push tag
         run: |

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">AccBot</string>
+    <string name="app_name">AccBot DCA</string>
 
     <!-- Common -->
     <string name="common_back">Back</string>


### PR DESCRIPTION
## Summary
- Fix auto-release tag not triggering the Android Release workflow (uses `PAT_GITHUB` instead of default `GITHUB_TOKEN` to allow tag push to trigger downstream workflows)
- Rename displayed app name from "AccBot" to "AccBot DCA" in launcher and system settings (`app_name` string resource)

## After merge
After merging this PR, regenerate the v2.2.1 release assets:
```bash
# Delete old release and tag
gh release delete v2.2.1 --yes
git push origin :refs/tags/v2.2.1

# Create new tag on updated main
git fetch origin main
git tag v2.2.1 origin/main
git push origin v2.2.1
```
This will trigger the Android Release workflow and rebuild all assets with the new app name.

## Test plan
- [ ] Verify the Android Release workflow triggers after tag push
- [ ] Verify release assets (APK/AAB) show "AccBot DCA" as app name in launcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)