### PR TITLE
Fix privacy page logo and i18n link rendering

### DIFF
--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -20,7 +20,11 @@
     for (var i = 0; i < els.length; i++) {
       var key = els[i].getAttribute('data-i18n');
       if (translations[key]) {
-        els[i].textContent = translations[key];
+        if (translations[key].indexOf('<') !== -1) {
+          els[i].innerHTML = translations[key];
+        } else {
+          els[i].textContent = translations[key];
+        }
       }
     }
     var placeholders = document.querySelectorAll('[data-i18n-placeholder]');

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -24,11 +24,36 @@
   <header class="site-header scrolled">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <svg width="32" height="32" viewBox="0 0 54 54" fill="none">
-          <circle cx="27" cy="27" r="27" fill="#4ECCA3"/>
-          <path d="M29.38,47.95v4.73h-4.05v-4.67c-1.7,-0.19 -3.43,-0.59 -5.16,-1.22l1,-4c1.57,0.57 3.19,1.05 4.84,1.05 2.03,0 3.08,-0.73 3.08,-1.95 0,-1.14 -0.89,-1.84 -3.08,-2.57 -3.43,-1.16 -5.56,-2.78 -5.56,-5.97 0,-2.86 2,-5.13 5.43,-5.84v-4.38h4.05v4.4c1.4,0.19 2.54,0.49 3.67,0.86l-0.84,3.86c-1.22,-0.43 -2.51,-0.86 -4.08,-0.86 -2.19,0 -2.86,0.92 -2.86,1.76 0,1 0.97,1.65 3.4,2.57 3.65,1.3 5.24,3.05 5.24,6.02 0,2.95 -2.08,5.32 -5.89,5.97z" fill="#1A1A2E" transform="translate(0,-13)"/>
-        </svg>
-        AccBot
+        <span class="logo-text">Acc<span class="logo-btc"><span class="logo-icon">
+          <svg width="48" height="48" viewBox="86 86 340 340" fill="none">
+            <defs>
+              <linearGradient id="hdrFade" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stop-color="white"/>
+                <stop offset="28%" stop-color="white"/>
+                <stop offset="40%" stop-color="black"/>
+                <stop offset="60%" stop-color="black"/>
+                <stop offset="72%" stop-color="white"/>
+                <stop offset="100%" stop-color="white"/>
+              </linearGradient>
+              <mask id="hdrMask">
+                <rect x="86" y="86" width="340" height="340" fill="url(#hdrFade)"/>
+              </mask>
+              <clipPath id="hdrClip"><circle cx="256" cy="256" r="138"/></clipPath>
+            </defs>
+            <g mask="url(#hdrMask)">
+              <circle cx="256" cy="256" r="170" fill="none" stroke="#4ECCA3" stroke-width="8" opacity="0.3"/>
+              <circle cx="256" cy="256" r="140" fill="#4ECCA3" fill-opacity="0.05" stroke="#4ECCA3" stroke-width="4"/>
+              <g clip-path="url(#hdrClip)">
+                <rect x="126" y="280" width="50" height="200" rx="6" fill="#4ECCA3" opacity="0.3"/>
+                <rect x="196" y="230" width="50" height="250" rx="6" fill="#4ECCA3" opacity="0.5"/>
+                <rect x="266" y="170" width="50" height="310" rx="6" fill="#4ECCA3" opacity="0.7"/>
+                <rect x="336" y="100" width="50" height="380" rx="6" fill="#4ECCA3" opacity="0.9"/>
+              </g>
+              <circle cx="256" cy="256" r="85" fill="#16213E" stroke="#4ECCA3" stroke-width="4"/>
+              <circle cx="256" cy="256" r="72" fill="none" stroke="#4ECCA3" stroke-width="2" stroke-dasharray="8 8" opacity="0.6"/>
+            </g>
+          </svg>
+        </span>&#x20bf;</span>ot</span>
       </a>
 
       <nav>


### PR DESCRIPTION
## Summary
- Fix header logo on privacy page to match the landing page (Acc₿ot with chart SVG)
- Fix i18n engine to render HTML links correctly — use `innerHTML` for translations containing HTML tags instead of `textContent` which escaped them as raw text
- Add explicit "Effective date" field to privacy policy for Google Play compliance

## Test plan
- [ ] Verify privacy page header logo matches index.html
- [ ] Verify Google Privacy Policy links in ML Kit sections render as clickable links (not raw HTML)
- [ ] Verify language switching (EN/CS) still works correctly
- [ ] Verify no XSS risk — only translation JSON files (developer-controlled) use innerHTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)