### PR TITLE
Polish light theme, Market Pulse collapse & settings toggle

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/UserPreferences.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/UserPreferences.kt
@@ -164,6 +164,24 @@ class UserPreferences @Inject constructor(
         prefs.edit().putInt(KEY_LAST_SEEN_VERSION_CODE, code).apply()
     }
 
+    // ==================== Market Pulse ====================
+
+    fun isMarketPulseEnabled(): Boolean {
+        return prefs.getBoolean(KEY_MARKET_PULSE_ENABLED, true)
+    }
+
+    fun setMarketPulseEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_MARKET_PULSE_ENABLED, enabled).apply()
+    }
+
+    fun isMarketPulseExpanded(): Boolean {
+        return prefs.getBoolean(KEY_MARKET_PULSE_EXPANDED, true)
+    }
+
+    fun setMarketPulseExpanded(expanded: Boolean) {
+        prefs.edit().putBoolean(KEY_MARKET_PULSE_EXPANDED, expanded).apply()
+    }
+
     // ==================== Sandbox Mode ====================
 
     /**
@@ -195,5 +213,7 @@ class UserPreferences @Inject constructor(
         private const val KEY_BIOMETRIC_LOCK_ENABLED = "biometric_lock_enabled"
         private const val KEY_LOW_BALANCE_THRESHOLD_DAYS = "low_balance_threshold_days"
         private const val KEY_LAST_SEEN_VERSION_CODE = "last_seen_version_code"
+        private const val KEY_MARKET_PULSE_ENABLED = "market_pulse_enabled"
+        private const val KEY_MARKET_PULSE_EXPANDED = "market_pulse_expanded"
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/model/DcaStrategy.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/model/DcaStrategy.kt
@@ -74,18 +74,18 @@ data class AthTier(
 )
 
 /**
- * Default ATH tiers:
- * - 0-10% below ATH: buy 50% (market is hot)
- * - 10-30% below: buy 100% (normal)
- * - 30-50% below: buy 150%
- * - 50-70% below: buy 200%
- * - 70%+ below: buy 300% (maximum opportunity)
+ * Default ATH tiers (even 20% bands):
+ * - 0-20% below ATH: buy 50% (near ATH)
+ * - 20-40% below: buy 100% (normal)
+ * - 40-60% below: buy 150%
+ * - 60-80% below: buy 200%
+ * - 80-100% below: buy 300% (maximum opportunity)
  */
 val defaultAthTiers = listOf(
-    AthTier(0.10f, 0.5f),
-    AthTier(0.30f, 1.0f),
-    AthTier(0.50f, 1.5f),
-    AthTier(0.70f, 2.0f),
+    AthTier(0.20f, 0.5f),
+    AthTier(0.40f, 1.0f),
+    AthTier(0.60f, 1.5f),
+    AthTier(0.80f, 2.0f),
     AthTier(1.00f, 3.0f)
 )
 
@@ -100,18 +100,18 @@ data class FearGreedTier(
 )
 
 /**
- * Default Fear & Greed tiers:
- * - Extreme Fear (0-24): buy 250%
- * - Fear (25-44): buy 150%
- * - Neutral (45-54): buy 100%
- * - Greed (55-74): buy 50%
- * - Extreme Greed (75-100): buy 25%
+ * Default Fear & Greed tiers (even 20-point bands):
+ * - Extreme Fear (0-19): buy 250%
+ * - Fear (20-39): buy 150%
+ * - Neutral (40-59): buy 100%
+ * - Greed (60-79): buy 50%
+ * - Extreme Greed (80-100): buy 25%
  */
 val defaultFearGreedTiers = listOf(
-    FearGreedTier(24, 2.5f),
-    FearGreedTier(44, 1.5f),
-    FearGreedTier(54, 1.0f),
-    FearGreedTier(74, 0.5f),
+    FearGreedTier(19, 2.5f),
+    FearGreedTier(39, 1.5f),
+    FearGreedTier(59, 1.0f),
+    FearGreedTier(79, 0.5f),
     FearGreedTier(100, 0.25f)
 )
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/CalculateChartDataUseCase.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/CalculateChartDataUseCase.kt
@@ -9,6 +9,7 @@ import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import java.time.temporal.WeekFields
 import javax.inject.Inject
 
@@ -101,8 +102,12 @@ class CalculateChartDataUseCase @Inject constructor(
             nextTx = if (txIterator.hasNext()) txIterator.next() else null
         }
 
-        val emitMonthly = zoomLevel is ChartZoomLevel.Overview
-        val emitWeekly = zoomLevel is ChartZoomLevel.Year
+        // Adaptive aggregation: Overview adapts based on history length
+        val historyMonths = if (zoomLevel is ChartZoomLevel.Overview)
+            ChronoUnit.MONTHS.between(startDate, endDate) else 0L
+        val emitMonthly = zoomLevel is ChartZoomLevel.Overview && historyMonths > 12
+        val emitWeekly = zoomLevel is ChartZoomLevel.Year ||
+            (zoomLevel is ChartZoomLevel.Overview && historyMonths in 3..12)
         val emitBucketed = emitMonthly || emitWeekly
         val result = mutableListOf<ChartDataPoint>()
         var lastKnownPrice: BigDecimal? = null
@@ -227,8 +232,12 @@ class CalculateChartDataUseCase @Inject constructor(
             }
         }
 
-        val emitMonthly = zoomLevel is ChartZoomLevel.Overview
-        val emitWeekly = zoomLevel is ChartZoomLevel.Year
+        // Adaptive aggregation: Overview adapts based on history length
+        val historyMonths = if (zoomLevel is ChartZoomLevel.Overview)
+            ChronoUnit.MONTHS.between(startDate, endDate) else 0L
+        val emitMonthly = zoomLevel is ChartZoomLevel.Overview && historyMonths > 12
+        val emitWeekly = zoomLevel is ChartZoomLevel.Year ||
+            (zoomLevel is ChartZoomLevel.Overview && historyMonths in 3..12)
         val emitBucketed = emitMonthly || emitWeekly
         val result = mutableListOf<ChartDataPoint>()
         var currentDate = startDate

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/ImportTradeHistoryUseCase.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/ImportTradeHistoryUseCase.kt
@@ -32,7 +32,8 @@ class ImportTradeHistoryUseCase @Inject constructor(
         planId: Long,
         crypto: String,
         fiat: String,
-        exchange: Exchange
+        exchange: Exchange,
+        sinceDate: Instant? = null
     ): Flow<ApiImportProgress> = flow {
         try {
             // Fetch all pages — always from the beginning.
@@ -66,6 +67,11 @@ class ImportTradeHistoryUseCase @Inject constructor(
 
                 if (!result.hasMore || page >= maxPages) break
             } while (true)
+
+            // Filter by sinceDate if provided
+            if (sinceDate != null) {
+                allTrades.removeAll { it.timestamp.isBefore(sinceDate) }
+            }
 
             if (allTrades.isEmpty()) {
                 emit(ApiImportProgress.Complete(imported = 0, skipped = 0))

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/ImportTradeHistoryUseCase.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/usecase/ImportTradeHistoryUseCase.kt
@@ -36,12 +36,12 @@ class ImportTradeHistoryUseCase @Inject constructor(
         sinceDate: Instant? = null
     ): Flow<ApiImportProgress> = flow {
         try {
-            // Fetch all pages — always from the beginning.
+            // Fetch all pages — from sinceDate if provided, otherwise from the beginning.
             // Deduplication by exchangeOrderId prevents duplicates, so there's no need
             // for a timestamp cursor which can skip historical trades when the only
             // existing transactions are from auto-buy (not from a prior API import).
             val allTrades = mutableListOf<com.accbot.dca.domain.model.HistoricalTrade>()
-            var cursor: Instant? = null
+            var cursor: Instant? = sinceDate
             var page = 0
             val maxPages = 10_000  // Safety cap only; pagination stops naturally via hasMore
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ChartComponents.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ChartComponents.kt
@@ -183,7 +183,12 @@ fun PortfolioLineChart(
 
     val xLabels = remember(chartData, zoomLevel) {
         val formatter = when (zoomLevel) {
-            is ChartZoomLevel.Overview -> DateTimeFormatter.ofPattern("MMM yyyy")
+            is ChartZoomLevel.Overview -> {
+                val spanDays = if (chartData.size >= 2)
+                    chartData.last().epochDay - chartData.first().epochDay else 0L
+                if (spanDays > 365) DateTimeFormatter.ofPattern("MMM yyyy")
+                else DateTimeFormatter.ofPattern("d MMM")
+            }
             is ChartZoomLevel.Year -> DateTimeFormatter.ofPattern("d MMM")
             is ChartZoomLevel.Month -> DateTimeFormatter.ofPattern("d")
         }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ChartComponents.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ChartComponents.kt
@@ -258,9 +258,15 @@ fun PortfolioLineChart(
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         textSize = 10.sp
     )
+    // Axis tick label styling — must be explicit for light theme support
+    val axisLabelComponent = rememberTextComponent(
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textSize = 10.sp
+    )
 
     // End (right) axis — accumulated crypto in BTC units
     val endAxisComponent = VerticalAxis.rememberEnd(
+        label = axisLabelComponent,
         title = cryptoSymbol,
         titleComponent = axisTitleComponent,
         itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
@@ -294,6 +300,7 @@ fun PortfolioLineChart(
                     verticalAxisPosition = Axis.Position.Vertical.End
                 ),
                 startAxis = VerticalAxis.rememberStart(
+                    label = axisLabelComponent,
                     title = unitSuffix,
                     titleComponent = axisTitleComponent,
                     itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
@@ -307,6 +314,7 @@ fun PortfolioLineChart(
                 ),
                 endAxis = if (hasRightAxis) endAxisComponent else null,
                 bottomAxis = HorizontalAxis.rememberBottom(
+                    label = axisLabelComponent,
                     valueFormatter = { _, value, _ ->
                         val index = value.toInt().coerceIn(0, xLabels.size - 1)
                         xLabels.getOrElse(index) { "" }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ImportConfigDialog.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ImportConfigDialog.kt
@@ -1,0 +1,129 @@
+package com.accbot.dca.presentation.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.accbot.dca.R
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportConfigDialog(
+    planCount: Int? = null,
+    sinceMillis: Long?,
+    onSinceDateChanged: (Long?) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+    val dateFormatter = remember {
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+    }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = sinceMillis,
+            selectableDates = object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                    return utcTimeMillis <= System.currentTimeMillis()
+                }
+            }
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    onSinceDateChanged(datePickerState.selectedDateMillis)
+                    showDatePicker = false
+                }) {
+                    Text(stringResource(R.string.common_done))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.import_api_title)) },
+        text = {
+            Column {
+                if (planCount != null) {
+                    Text(stringResource(R.string.import_api_dialog_text, planCount))
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+                Text(
+                    text = stringResource(R.string.import_api_from_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedCard(
+                    onClick = { showDatePicker = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = if (sinceMillis != null)
+                                dateFormatter.format(Instant.ofEpochMilli(sinceMillis))
+                            else
+                                stringResource(R.string.import_api_all_history),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        if (sinceMillis != null) {
+                            IconButton(
+                                onClick = { onSinceDateChanged(null) },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Clear,
+                                    contentDescription = stringResource(R.string.import_api_all_history),
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.CalendarMonth,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.import_api_start))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_cancel))
+            }
+        }
+    )
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/StrategyInfoBottomSheet.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/StrategyInfoBottomSheet.kt
@@ -237,11 +237,11 @@ private fun AthBasedStrategyContent(currentMultiplier: Float?) {
                 HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
                 // Rows
-                TierRow(stringResource(R.string.strategy_ath_tier_0_10), stringResource(R.string.strategy_ath_mult_50))
-                TierRow(stringResource(R.string.strategy_ath_tier_10_30), stringResource(R.string.strategy_ath_mult_100))
-                TierRow(stringResource(R.string.strategy_ath_tier_30_50), stringResource(R.string.strategy_ath_mult_150))
-                TierRow(stringResource(R.string.strategy_ath_tier_50_70), stringResource(R.string.strategy_ath_mult_200))
-                TierRow(stringResource(R.string.strategy_ath_tier_70_plus), stringResource(R.string.strategy_ath_mult_300))
+                TierRow(stringResource(R.string.strategy_ath_tier_0_20), stringResource(R.string.strategy_ath_mult_50))
+                TierRow(stringResource(R.string.strategy_ath_tier_20_40), stringResource(R.string.strategy_ath_mult_100))
+                TierRow(stringResource(R.string.strategy_ath_tier_40_60), stringResource(R.string.strategy_ath_mult_150))
+                TierRow(stringResource(R.string.strategy_ath_tier_60_80), stringResource(R.string.strategy_ath_mult_200))
+                TierRow(stringResource(R.string.strategy_ath_tier_80_100), stringResource(R.string.strategy_ath_mult_300))
             }
         }
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
@@ -1,6 +1,10 @@
 package com.accbot.dca.presentation.screens
 
 import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -17,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
@@ -29,6 +34,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.Layout
@@ -44,8 +50,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
+import com.accbot.dca.data.remote.CryptoData
+import com.accbot.dca.data.remote.FearGreedData
 import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.DcaStrategy
 import com.accbot.dca.domain.util.CronUtils
@@ -79,7 +90,17 @@ fun DashboardScreen(
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
-    // Ticker moved into DcaPlanCard – see currentTime state there
+    // Re-read preferences (e.g. Market Pulse toggle) when returning from Settings
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshPreferences()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     LaunchedEffect(uiState.runNowTriggered) {
         if (uiState.runNowTriggered) {
@@ -108,12 +129,18 @@ fun DashboardScreen(
             )
         },
     ) { paddingValues ->
+        PullToRefreshBox(
+            isRefreshing = uiState.isPriceLoading,
+            onRefresh = { viewModel.refreshAll() },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
         if (isLandscape) {
             // Landscape: two-column layout
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
                     .padding(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
@@ -124,8 +151,6 @@ fun DashboardScreen(
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Spacer(modifier = Modifier.height(8.dp))
-
                     if (uiState.isSandboxMode) {
                         SandboxBanner()
                     }
@@ -136,8 +161,6 @@ fun DashboardScreen(
 
                     HoldingsPager(
                         holdings = uiState.holdings,
-                        isPriceLoading = uiState.isPriceLoading,
-                        onRefreshPrices = { viewModel.refreshPrices() },
                         onHoldingClick = onNavigateToPortfolio,
                         onImportViaApi = onNavigateToExchangeDetail?.let { nav ->
                             {
@@ -147,6 +170,15 @@ fun DashboardScreen(
                         },
                         compact = true
                     )
+
+                    if (uiState.showMarketPulse && (uiState.fearGreedData != null || uiState.athDataByCrypto.isNotEmpty())) {
+                        MarketPulseCard(
+                            fearGreedData = uiState.fearGreedData,
+                            athDataByCrypto = uiState.athDataByCrypto,
+                            isExpanded = uiState.isMarketPulseExpanded,
+                            onToggleExpand = { viewModel.toggleMarketPulseExpanded() }
+                        )
+                    }
 
                     QuickActionsRow(
                         onViewHistory = onNavigateToHistory,
@@ -161,10 +193,6 @@ fun DashboardScreen(
                     modifier = Modifier.weight(0.5f),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    item {
-                        Spacer(modifier = Modifier.height(8.dp))
-                    }
-
                     item {
                         SectionHeader(
                             title = stringResource(R.string.dashboard_active_plans),
@@ -209,14 +237,9 @@ fun DashboardScreen(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
                     .padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                item {
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-
                 // Sandbox Mode Banner
                 if (uiState.isSandboxMode) {
                     item {
@@ -235,8 +258,6 @@ fun DashboardScreen(
                 item {
                     HoldingsPager(
                         holdings = uiState.holdings,
-                        isPriceLoading = uiState.isPriceLoading,
-                        onRefreshPrices = { viewModel.refreshPrices() },
                         onHoldingClick = onNavigateToPortfolio,
                         onImportViaApi = onNavigateToExchangeDetail?.let { nav ->
                             {
@@ -245,6 +266,18 @@ fun DashboardScreen(
                             }
                         }
                     )
+                }
+
+                // Market Pulse
+                if (uiState.showMarketPulse && (uiState.fearGreedData != null || uiState.athDataByCrypto.isNotEmpty())) {
+                    item {
+                        MarketPulseCard(
+                            fearGreedData = uiState.fearGreedData,
+                            athDataByCrypto = uiState.athDataByCrypto,
+                            isExpanded = uiState.isMarketPulseExpanded,
+                            onToggleExpand = { viewModel.toggleMarketPulseExpanded() }
+                        )
+                    }
                 }
 
                 // My DCA Plans
@@ -294,6 +327,7 @@ fun DashboardScreen(
                 }
             }
         }
+        } // PullToRefreshBox
     }
 }
 
@@ -400,8 +434,6 @@ internal fun SandboxBanner() {
 @Composable
 internal fun HoldingsPager(
     holdings: List<CryptoHoldingWithPrice>,
-    isPriceLoading: Boolean,
-    onRefreshPrices: () -> Unit,
     onHoldingClick: ((String, String) -> Unit)? = null,
     onImportViaApi: (() -> Unit)? = null,
     compact: Boolean = false
@@ -474,37 +506,12 @@ internal fun HoldingsPager(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Header with refresh button
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 20.dp, end = 8.dp, top = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.dashboard_total_accumulated),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                IconButton(
-                    onClick = onRefreshPrices
-                ) {
-                    if (isPriceLoading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Default.Refresh,
-                            contentDescription = stringResource(R.string.dashboard_refresh_prices),
-                            modifier = Modifier.size(18.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-            }
+            Text(
+                text = stringResource(R.string.dashboard_total_accumulated),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 20.dp, top = 12.dp)
+            )
 
             HorizontalPager(
                 state = pagerState,
@@ -760,8 +767,28 @@ internal fun DcaPlanCard(
                     } else {
                         stringResource(plan.frequency.displayNameRes)
                     }
+                    val multiplierResult = planWithBalance.strategyMultiplier
+                    val amountText = if (multiplierResult != null && multiplierResult.multiplier != 1.0f) {
+                        val effective = plan.amount.multiply(BigDecimal(multiplierResult.multiplier.toString()))
+                            .setScale(plan.amount.scale().coerceAtLeast(0), RoundingMode.HALF_UP)
+                        val multiplierStr = if (multiplierResult.multiplier % 1.0f == 0f) {
+                            multiplierResult.multiplier.toInt().toString()
+                        } else {
+                            multiplierResult.multiplier.toString()
+                        }
+                        stringResource(
+                            R.string.dashboard_purchase_amount_formula,
+                            effective.toPlainString(),
+                            plan.fiat,
+                            plan.amount.toPlainString(),
+                            multiplierStr,
+                            frequencyText
+                        )
+                    } else {
+                        "${plan.amount} ${plan.fiat} • $frequencyText"
+                    }
                     Text(
-                        text = "${plan.amount} ${plan.fiat} • $frequencyText",
+                        text = amountText,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -862,7 +889,9 @@ internal fun DcaPlanCard(
                                 .fillMaxWidth()
                                 .height(4.dp),
                             color = goalColor,
-                            trackColor = goalColor.copy(alpha = 0.2f)
+                            trackColor = goalColor.copy(alpha = 0.2f),
+                            gapSize = 0.dp,
+                            drawStopIndicator = {}
                         )
                         Text(
                             text = if (goalReached) {
@@ -1136,8 +1165,21 @@ private fun RunNowBottomSheet(
                                 color = MaterialTheme.colorScheme.primary
                             )
                         }
+                        val sheetMultiplier = planWithBalance.strategyMultiplier
+                        val sheetAmountText = if (sheetMultiplier != null && sheetMultiplier.multiplier != 1.0f) {
+                            val effective = plan.amount.multiply(BigDecimal(sheetMultiplier.multiplier.toString()))
+                                .setScale(plan.amount.scale().coerceAtLeast(0), RoundingMode.HALF_UP)
+                            val multiplierStr = if (sheetMultiplier.multiplier % 1.0f == 0f) {
+                                sheetMultiplier.multiplier.toInt().toString()
+                            } else {
+                                sheetMultiplier.multiplier.toString()
+                            }
+                            "${effective.toPlainString()} ${plan.fiat} (${plan.amount.toPlainString()} × $multiplierStr) • ${plan.exchange.displayName}"
+                        } else {
+                            "${plan.amount} ${plan.fiat} • ${plan.exchange.displayName}"
+                        }
                         Text(
-                            text = "${plan.amount} ${plan.fiat} • ${plan.exchange.displayName}",
+                            text = sheetAmountText,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -1157,5 +1199,236 @@ private fun RunNowBottomSheet(
                 Text(stringResource(R.string.run_now_confirm, selectedIds.size))
             }
         }
+    }
+}
+
+@Composable
+internal fun MarketPulseCard(
+    fearGreedData: FearGreedData?,
+    athDataByCrypto: Map<String, CryptoData>,
+    isExpanded: Boolean = true,
+    onToggleExpand: () -> Unit = {}
+) {
+    val indicatorColor = MaterialTheme.colorScheme.onSurface
+
+    // Localized F&G classification
+    val localizedClassification = fearGreedData?.let { localizedFearGreedClass(it.value) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggleExpand),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.dashboard_market_pulse),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Icon(
+                    imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = if (isExpanded) stringResource(R.string.common_collapse) else stringResource(R.string.common_expand),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            // Gauge area
+            Column(modifier = Modifier.fillMaxWidth()) {
+
+                // Expanded: show labels above the bar
+                AnimatedVisibility(
+                    visible = isExpanded,
+                    enter = expandVertically(),
+                    exit = shrinkVertically()
+                ) {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        // "Fear & Greed" centered above
+                        if (fearGreedData != null) {
+                            Text(
+                                text = stringResource(R.string.dashboard_fear_greed),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.fillMaxWidth(),
+                                textAlign = TextAlign.Center
+                            )
+
+                            // Row: "Fear" (left) — "14 — Extreme Fear" (center) — "Greed" (right)
+                            Box(modifier = Modifier.fillMaxWidth()) {
+                                Text(
+                                    text = stringResource(R.string.dashboard_fear_label),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.align(Alignment.CenterStart)
+                                )
+                                Text(
+                                    text = "${fearGreedData.value} — $localizedClassification",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = fearGreedColor(fearGreedData.value),
+                                    modifier = Modifier.align(Alignment.Center)
+                                )
+                                Text(
+                                    text = stringResource(R.string.dashboard_greed_label),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.align(Alignment.CenterEnd)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // ▼ Fear & Greed triangle (always visible)
+                if (fearGreedData != null) {
+                    Canvas(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                    ) {
+                        val w = 8.dp.toPx(); val h = 6.dp.toPx()
+                        val x = (fearGreedData.value / 100f).coerceIn(0f, 1f) * size.width
+                        val path = Path().apply {
+                            moveTo(x - w / 2, size.height - h)
+                            lineTo(x + w / 2, size.height - h)
+                            lineTo(x, size.height)
+                            close()
+                        }
+                        drawPath(path, color = indicatorColor)
+                    }
+                }
+
+                // Colored bar (always visible)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    gaugeColors.forEach { color ->
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(8.dp)
+                                .background(color, RoundedCornerShape(2.dp))
+                        )
+                    }
+                }
+
+                // ▲ ATH triangles (always visible)
+                if (athDataByCrypto.isNotEmpty()) {
+                    Canvas(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                    ) {
+                        val w = 8.dp.toPx(); val h = 6.dp.toPx()
+                        athDataByCrypto.values.forEach { data ->
+                            val x = (1.0f - data.athDistance).coerceIn(0f, 1f) * size.width
+                            val path = Path().apply {
+                                moveTo(x, 0f)
+                                lineTo(x - w / 2, h)
+                                lineTo(x + w / 2, h)
+                                close()
+                            }
+                            drawPath(path, color = indicatorColor)
+                        }
+                    }
+                }
+
+                // Expanded: show labels below the bar
+                AnimatedVisibility(
+                    visible = isExpanded,
+                    enter = expandVertically(),
+                    exit = shrinkVertically()
+                ) {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        if (athDataByCrypto.isNotEmpty()) {
+                            // Row: "0" (left) — "BTC -35 %" (center) — "ATH" (right)
+                            val athCenterText = if (athDataByCrypto.size == 1) {
+                                val entry = athDataByCrypto.entries.first()
+                                "-%d %%".format(entry.value.athDistancePercent)
+                            } else {
+                                athDataByCrypto.entries.joinToString(", ") { (crypto, data) ->
+                                    "%s -%d %%".format(crypto, data.athDistancePercent)
+                                }
+                            }
+                            Box(modifier = Modifier.fillMaxWidth()) {
+                                Text(
+                                    text = "0",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.align(Alignment.CenterStart)
+                                )
+                                Text(
+                                    text = athCenterText,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.align(Alignment.Center)
+                                )
+                                Text(
+                                    text = "ATH",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.align(Alignment.CenterEnd)
+                                )
+                            }
+
+                            // "ATH Distance" / "Vzdálenost od ATH" centered below
+                            Text(
+                                text = stringResource(R.string.dashboard_ath_distance),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.fillMaxWidth(),
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun localizedFearGreedClass(value: Int): String {
+    return when {
+        value <= 19 -> stringResource(R.string.fg_class_extreme_fear)
+        value <= 39 -> stringResource(R.string.fg_class_fear)
+        value <= 59 -> stringResource(R.string.fg_class_neutral)
+        value <= 79 -> stringResource(R.string.fg_class_greed)
+        else -> stringResource(R.string.fg_class_extreme_greed)
+    }
+}
+
+private val gaugeColors = listOf(
+    Color(0xFFE53935),
+    Color(0xFFFF9800),
+    Color(0xFFFDD835),
+    Color(0xFF8BC34A),
+    Color(0xFF4CAF50)
+)
+
+private fun fearGreedColor(value: Int): Color {
+    return when {
+        value <= 19 -> Color(0xFFE53935) // Extreme Fear - red
+        value <= 39 -> Color(0xFFFF9800) // Fear - orange
+        value <= 59 -> Color(0xFFFDD835) // Neutral - yellow
+        value <= 79 -> Color(0xFF8BC34A) // Greed - light green
+        else -> Color(0xFF4CAF50)        // Extreme Greed - green
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardViewModel.kt
@@ -13,8 +13,13 @@ import com.accbot.dca.data.local.TransactionDao
 import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.data.local.WithdrawalThresholdDao
 import com.accbot.dca.data.local.toDomain
+import com.accbot.dca.data.remote.CryptoData
+import com.accbot.dca.data.remote.FearGreedData
 import com.accbot.dca.data.remote.MarketDataService
 import com.accbot.dca.domain.model.DcaPlan
+import com.accbot.dca.domain.model.DcaStrategy
+import com.accbot.dca.domain.model.StrategyMultiplierResult
+import com.accbot.dca.domain.usecase.CalculateStrategyMultiplierUseCase
 import com.accbot.dca.exchange.ExchangeApiFactory
 import com.accbot.dca.scheduler.DcaAlarmScheduler
 import com.accbot.dca.service.DcaForegroundService
@@ -22,6 +27,7 @@ import com.accbot.dca.worker.DcaWorker
 import androidx.compose.runtime.Immutable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -55,7 +61,8 @@ data class DcaPlanWithBalance(
     val isLowBalance: Boolean = false,
     val isOverWithdrawalThreshold: Boolean = false,
     val exchangeCryptoBalance: BigDecimal? = null,
-    val accumulatedCrypto: BigDecimal? = null
+    val accumulatedCrypto: BigDecimal? = null,
+    val strategyMultiplier: StrategyMultiplierResult? = null
 )
 
 @Immutable
@@ -66,7 +73,12 @@ data class DashboardUiState(
     val isPriceLoading: Boolean = false,
     val isSandboxMode: Boolean = false,
     val runNowTriggered: Boolean = false,
-    val showRunNowSheet: Boolean = false
+    val showRunNowSheet: Boolean = false,
+    val fearGreedData: FearGreedData? = null,
+    val athDataByCrypto: Map<String, CryptoData> = emptyMap(),
+    val isMarketDataLoading: Boolean = false,
+    val showMarketPulse: Boolean = true,
+    val isMarketPulseExpanded: Boolean = true
 )
 
 @HiltViewModel
@@ -79,7 +91,8 @@ class DashboardViewModel @Inject constructor(
     private val exchangeApiFactory: ExchangeApiFactory,
     private val credentialsStore: CredentialsStore,
     private val exchangeBalanceDao: ExchangeBalanceDao,
-    private val withdrawalThresholdDao: WithdrawalThresholdDao
+    private val withdrawalThresholdDao: WithdrawalThresholdDao,
+    private val calculateStrategyMultiplier: CalculateStrategyMultiplierUseCase
 ) : AndroidViewModel(application) {
 
     companion object {
@@ -101,7 +114,16 @@ class DashboardViewModel @Inject constructor(
         loadDataJob?.cancel()
         loadDataJob = viewModelScope.launch {
             val isSandbox = userPreferences.isSandboxMode()
-            _uiState.update { it.copy(isLoading = true, isSandboxMode = isSandbox) }
+            val showMarketPulse = userPreferences.isMarketPulseEnabled()
+            val isMarketPulseExpanded = userPreferences.isMarketPulseExpanded()
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    isSandboxMode = isSandbox,
+                    showMarketPulse = showMarketPulse,
+                    isMarketPulseExpanded = isMarketPulseExpanded
+                )
+            }
 
             combine(
                 dcaPlanDao.getAllPlans(),
@@ -109,6 +131,7 @@ class DashboardViewModel @Inject constructor(
             ) { planEntities, dbHoldings ->
                 Pair(planEntities, dbHoldings)
             }.collectLatest { (planEntities, dbHoldings) ->
+                refreshPricesJob?.cancel()
                 val plans = planEntities.map { it.toDomain() }
 
                 val holdings = mapHoldings(dbHoldings)
@@ -125,18 +148,39 @@ class DashboardViewModel @Inject constructor(
                     DcaPlanWithBalance(plan = plan, accumulatedCrypto = accumulated)
                 }
 
+                // Merge existing prices into fresh holdings to avoid KPI flash
+                val existingPrices = _uiState.value.holdings.associateBy(
+                    { "${it.crypto}/${it.fiat}" },
+                    { it }
+                )
+                val mergedHoldings = holdings.map { h ->
+                    val key = "${h.crypto}/${h.fiat}"
+                    val existing = existingPrices[key]
+                    if (existing?.currentPrice != null) {
+                        h.copy(
+                            currentPrice = existing.currentPrice,
+                            currentValue = existing.currentValue,
+                            roiAbsolute = existing.roiAbsolute,
+                            roiPercent = existing.roiPercent
+                        )
+                    } else h
+                }
+
                 _uiState.update { state ->
                     state.copy(
                         activePlans = plansWithBalance,
-                        holdings = holdings,
+                        holdings = mergedHoldings,
                         isLoading = false
                     )
                 }
 
                 // collectLatest cancels previous block on new emission,
                 // so these child coroutines are automatically cancelled
-                launch { fetchPricesForHoldings(holdings) }
+                launch { fetchPricesForHoldings(mergedHoldings) }
                 launch { fetchBalancesForPlans(plans, isSandbox) }
+                if (showMarketPulse) {
+                    launch { fetchMarketIndicators(plans) }
+                }
             }
         }
     }
@@ -169,9 +213,12 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
-    private suspend fun fetchPricesForHoldings(holdings: List<CryptoHoldingWithPrice>) {
+    private suspend fun fetchPricesForHoldings(
+        holdings: List<CryptoHoldingWithPrice>,
+        manageLoadingState: Boolean = true
+    ) {
         if (holdings.isEmpty()) return
-        _uiState.update { it.copy(isPriceLoading = true) }
+        if (manageLoadingState) _uiState.update { it.copy(isPriceLoading = true) }
         val updatedHoldings = holdings.map { holding ->
             try {
                 val price = marketDataService.getCachedPrice(holding.crypto, holding.fiat)
@@ -196,7 +243,11 @@ class DashboardViewModel @Inject constructor(
             }
         }
         coroutineContext.ensureActive()
-        _uiState.update { it.copy(holdings = updatedHoldings, isPriceLoading = false) }
+        if (manageLoadingState) {
+            _uiState.update { it.copy(holdings = updatedHoldings, isPriceLoading = false) }
+        } else {
+            _uiState.update { it.copy(holdings = updatedHoldings) }
+        }
     }
 
     private suspend fun fetchBalancesForPlans(plans: List<DcaPlan>, isSandbox: Boolean) {
@@ -299,11 +350,98 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
-    fun refreshPrices() {
+    private suspend fun fetchMarketIndicators(plans: List<DcaPlan>) {
+        _uiState.update { it.copy(isMarketDataLoading = true) }
+        try {
+            // Fetch Fear & Greed index
+            val fearGreed = try {
+                marketDataService.getFearGreedIndex()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching Fear & Greed index", e)
+                null
+            }
+
+            // Fetch ATH data for each unique crypto/fiat pair
+            val uniquePairs = plans.map { it.crypto to it.fiat }.distinct()
+            val athData = mutableMapOf<String, CryptoData>()
+            for ((crypto, fiat) in uniquePairs) {
+                try {
+                    val data = marketDataService.getCryptoData(crypto, fiat)
+                    if (data != null) {
+                        athData[crypto] = data
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error fetching ATH data for $crypto/$fiat", e)
+                }
+            }
+
+            coroutineContext.ensureActive()
+            val currentCryptos = plans.map { it.crypto }.toSet()
+            _uiState.update { it.copy(
+                fearGreedData = fearGreed ?: it.fearGreedData,
+                athDataByCrypto = if (athData.isNotEmpty()) athData
+                    else it.athDataByCrypto.filterKeys { k -> k in currentCryptos },
+                isMarketDataLoading = false
+            ) }
+
+            // Calculate strategy multipliers for non-Classic plans
+            val nonClassicPlans = plans.filter { it.strategy !is DcaStrategy.Classic }
+            if (nonClassicPlans.isNotEmpty()) {
+                val multipliers = mutableMapOf<Long, StrategyMultiplierResult>()
+                for (plan in nonClassicPlans) {
+                    try {
+                        val result = calculateStrategyMultiplier(plan.strategy, plan.crypto, plan.fiat)
+                        multipliers[plan.id] = result
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error calculating multiplier for plan ${plan.id}", e)
+                    }
+                }
+
+                coroutineContext.ensureActive()
+                _uiState.update { current ->
+                    current.copy(
+                        activePlans = current.activePlans.map { pwb ->
+                            val mult = multipliers[pwb.plan.id]
+                            if (mult != null) pwb.copy(strategyMultiplier = mult) else pwb
+                        }
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching market indicators", e)
+            _uiState.update { it.copy(isMarketDataLoading = false) }
+        }
+    }
+
+    fun refreshPreferences() {
+        _uiState.update {
+            it.copy(showMarketPulse = userPreferences.isMarketPulseEnabled())
+        }
+    }
+
+    fun toggleMarketPulseExpanded() {
+        val newValue = !_uiState.value.isMarketPulseExpanded
+        userPreferences.setMarketPulseExpanded(newValue)
+        _uiState.update { it.copy(isMarketPulseExpanded = newValue) }
+    }
+
+    fun refreshAll() {
         marketDataService.invalidateCache()
         refreshPricesJob?.cancel()
         refreshPricesJob = viewModelScope.launch {
-            fetchPricesForHoldings(_uiState.value.holdings)
+            _uiState.update { it.copy(isPriceLoading = true) }
+            try {
+                val state = _uiState.value
+                val plans = state.activePlans.map { it.plan }
+                coroutineScope {
+                    launch { fetchPricesForHoldings(state.holdings, manageLoadingState = false) }
+                    if (state.showMarketPulse) {
+                        launch { fetchMarketIndicators(plans) }
+                    }
+                }
+            } finally {
+                _uiState.update { it.copy(isPriceLoading = false) }
+            }
         }
     }
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsScreen.kt
@@ -479,6 +479,13 @@ fun SettingsScreen(
             }
 
             item {
+                MarketPulseToggleCard(
+                    isEnabled = uiState.isMarketPulseEnabled,
+                    onToggle = { viewModel.setMarketPulseEnabled(it) }
+                )
+            }
+
+            item {
                 SettingsCardBase(
                     title = stringResource(R.string.settings_notifications),
                     subtitle = stringResource(R.string.settings_notifications_subtitle),
@@ -967,6 +974,37 @@ internal fun BiometricToggleCard(
         title = stringResource(R.string.biometric_lock_title),
         subtitle = stringResource(R.string.biometric_lock_subtitle),
         icon = Icons.Default.Fingerprint,
+        iconTint = if (isEnabled) accent else MaterialTheme.colorScheme.onSurfaceVariant,
+        onClick = {
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            onToggle(!isEnabled)
+        },
+        cardModifier = Modifier.semantics(mergeDescendants = true) { role = Role.Switch },
+        trailing = {
+            Switch(
+                checked = isEnabled,
+                onCheckedChange = null,
+                modifier = Modifier.clearAndSetSemantics {},
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = accent,
+                    checkedTrackColor = accent.copy(alpha = 0.5f)
+                )
+            )
+        }
+    )
+}
+
+@Composable
+internal fun MarketPulseToggleCard(
+    isEnabled: Boolean,
+    onToggle: (Boolean) -> Unit
+) {
+    val accent = successColor()
+    val haptic = LocalHapticFeedback.current
+    SettingsCardBase(
+        title = stringResource(R.string.settings_market_pulse_title),
+        subtitle = stringResource(R.string.settings_market_pulse_subtitle),
+        icon = Icons.AutoMirrored.Filled.ShowChart,
         iconTint = if (isEnabled) accent else MaterialTheme.colorScheme.onSurfaceVariant,
         onClick = {
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
@@ -45,6 +45,7 @@ data class SettingsUiState(
     val isBiometricLockEnabled: Boolean = false,
     val withdrawalThresholds: List<WithdrawalThreshold> = emptyList(),
     val availableCryptoExchangePairs: List<Pair<String, Exchange>> = emptyList(),
+    val isMarketPulseEnabled: Boolean = true,
     val appTheme: AppTheme = AppTheme.DARK,
     val dcaPlanCount: Int = 0,
     val transactionCount: Int = 0,
@@ -98,7 +99,8 @@ class SettingsViewModel @Inject constructor(
                 lowBalanceThresholdDays = userPreferences.getLowBalanceThresholdDays(),
                 languageTag = userPreferences.getLanguageTag(),
                 appTheme = userPreferences.getAppTheme(),
-                isBiometricLockEnabled = userPreferences.isBiometricLockEnabled()
+                isBiometricLockEnabled = userPreferences.isBiometricLockEnabled(),
+                isMarketPulseEnabled = userPreferences.isMarketPulseEnabled()
             )
         }
     }
@@ -151,6 +153,11 @@ class SettingsViewModel @Inject constructor(
     @Deprecated("Use requestSandboxModeChange() instead - requires app restart")
     fun toggleSandboxMode() {
         requestSandboxModeChange()
+    }
+
+    fun setMarketPulseEnabled(enabled: Boolean) {
+        userPreferences.setMarketPulseEnabled(enabled)
+        _uiState.update { it.copy(isMarketPulseEnabled = enabled) }
     }
 
     fun setBiometricLockEnabled(enabled: Boolean) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailScreen.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CalendarMonth
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ExpandMore
@@ -32,13 +30,10 @@ import com.accbot.dca.domain.usecase.ApiImportResultState
 import com.accbot.dca.presentation.components.AccBotTopAppBar
 import com.accbot.dca.presentation.components.CredentialsInputCard
 import com.accbot.dca.presentation.components.ExchangeAvatar
+import com.accbot.dca.presentation.components.ImportConfigDialog
 import com.accbot.dca.presentation.ui.theme.Error
 import com.accbot.dca.presentation.ui.theme.accentColor
 import com.accbot.dca.presentation.ui.theme.successColor
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -380,107 +375,4 @@ fun ExchangeDetailScreen(
         }
         } // Box
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ImportConfigDialog(
-    planCount: Int,
-    sinceMillis: Long?,
-    onSinceDateChanged: (Long?) -> Unit,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    var showDatePicker by remember { mutableStateOf(false) }
-    val dateFormatter = remember {
-        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
-    }
-
-    if (showDatePicker) {
-        val datePickerState = rememberDatePickerState(initialSelectedDateMillis = sinceMillis)
-        DatePickerDialog(
-            onDismissRequest = { showDatePicker = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    onSinceDateChanged(datePickerState.selectedDateMillis)
-                    showDatePicker = false
-                }) {
-                    Text(stringResource(R.string.common_done))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDatePicker = false }) {
-                    Text(stringResource(R.string.common_cancel))
-                }
-            }
-        ) {
-            DatePicker(state = datePickerState)
-        }
-    }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.import_api_title)) },
-        text = {
-            Column {
-                Text(stringResource(R.string.import_api_dialog_text, planCount))
-                Spacer(modifier = Modifier.height(16.dp))
-                Text(
-                    text = stringResource(R.string.import_api_from_label),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                OutlinedCard(
-                    onClick = { showDatePicker = true },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(12.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = if (sinceMillis != null)
-                                dateFormatter.format(Instant.ofEpochMilli(sinceMillis))
-                            else
-                                stringResource(R.string.import_api_all_history),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        if (sinceMillis != null) {
-                            IconButton(
-                                onClick = { onSinceDateChanged(null) },
-                                modifier = Modifier.size(24.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Clear,
-                                    contentDescription = stringResource(R.string.import_api_all_history),
-                                    modifier = Modifier.size(18.dp)
-                                )
-                            }
-                        } else {
-                            Icon(
-                                imageVector = Icons.Default.CalendarMonth,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.import_api_start))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.common_cancel))
-            }
-        }
-    )
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ExpandMore
@@ -33,6 +35,10 @@ import com.accbot.dca.presentation.components.ExchangeAvatar
 import com.accbot.dca.presentation.ui.theme.Error
 import com.accbot.dca.presentation.ui.theme.accentColor
 import com.accbot.dca.presentation.ui.theme.successColor
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -111,6 +117,17 @@ fun ExchangeDetailScreen(
                     Text(stringResource(R.string.common_cancel))
                 }
             }
+        )
+    }
+
+    // Import configuration dialog
+    if (uiState.showImportDialog) {
+        ImportConfigDialog(
+            planCount = uiState.plans.size,
+            sinceMillis = uiState.importSinceMillis,
+            onSinceDateChanged = { viewModel.setImportSinceDate(it) },
+            onConfirm = { viewModel.confirmImport() },
+            onDismiss = { viewModel.dismissImportDialog() }
         )
     }
 
@@ -286,7 +303,7 @@ fun ExchangeDetailScreen(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Card(
-                    onClick = { viewModel.importViaApi() },
+                    onClick = { viewModel.showImportDialog() },
                     enabled = !uiState.isApiImporting && uiState.plans.isNotEmpty(),
                     modifier = Modifier.fillMaxWidth(),
                     colors = CardDefaults.cardColors(
@@ -363,4 +380,107 @@ fun ExchangeDetailScreen(
         }
         } // Box
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImportConfigDialog(
+    planCount: Int,
+    sinceMillis: Long?,
+    onSinceDateChanged: (Long?) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+    val dateFormatter = remember {
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+    }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(initialSelectedDateMillis = sinceMillis)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    onSinceDateChanged(datePickerState.selectedDateMillis)
+                    showDatePicker = false
+                }) {
+                    Text(stringResource(R.string.common_done))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.import_api_title)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.import_api_dialog_text, planCount))
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.import_api_from_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedCard(
+                    onClick = { showDatePicker = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = if (sinceMillis != null)
+                                dateFormatter.format(Instant.ofEpochMilli(sinceMillis))
+                            else
+                                stringResource(R.string.import_api_all_history),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        if (sinceMillis != null) {
+                            IconButton(
+                                onClick = { onSinceDateChanged(null) },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Clear,
+                                    contentDescription = stringResource(R.string.import_api_all_history),
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.CalendarMonth,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.import_api_start))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_cancel))
+            }
+        }
+    )
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailViewModel.kt
@@ -22,6 +22,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.Immutable
+import java.time.Instant
 import javax.inject.Inject
 
 @Immutable
@@ -38,7 +39,9 @@ data class ExchangeDetailUiState(
     val plans: List<DcaPlanEntity> = emptyList(),
     val isApiImporting: Boolean = false,
     val apiImportProgress: String = "",
-    val apiImportResult: ApiImportResultState? = null
+    val apiImportResult: ApiImportResultState? = null,
+    val showImportDialog: Boolean = false,
+    val importSinceMillis: Long? = null
 )
 
 @HiltViewModel
@@ -143,7 +146,25 @@ class ExchangeDetailViewModel @Inject constructor(
         }
     }
 
-    fun importViaApi() {
+    fun showImportDialog() {
+        _uiState.update { it.copy(showImportDialog = true, importSinceMillis = null) }
+    }
+
+    fun dismissImportDialog() {
+        _uiState.update { it.copy(showImportDialog = false) }
+    }
+
+    fun setImportSinceDate(millis: Long?) {
+        _uiState.update { it.copy(importSinceMillis = millis) }
+    }
+
+    fun confirmImport() {
+        _uiState.update { it.copy(showImportDialog = false) }
+        val sinceDate = _uiState.value.importSinceMillis?.let { Instant.ofEpochMilli(it) }
+        importViaApi(sinceDate)
+    }
+
+    fun importViaApi(sinceDate: Instant? = null) {
         val state = _uiState.value
         val exchange = state.exchange ?: return
         if (state.isApiImporting) return
@@ -175,7 +196,8 @@ class ExchangeDetailViewModel @Inject constructor(
                         planId = plan.id,
                         crypto = plan.crypto,
                         fiat = plan.fiat,
-                        exchange = exchange
+                        exchange = exchange,
+                        sinceDate = sinceDate
                     ).collect { progress ->
                         when (progress) {
                             is ApiImportProgress.Fetching -> {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeDetailViewModel.kt
@@ -159,9 +159,9 @@ class ExchangeDetailViewModel @Inject constructor(
     }
 
     fun confirmImport() {
+        val sinceMillis = _uiState.value.importSinceMillis
         _uiState.update { it.copy(showImportDialog = false) }
-        val sinceDate = _uiState.value.importSinceMillis?.let { Instant.ofEpochMilli(it) }
-        importViaApi(sinceDate)
+        importViaApi(sinceMillis?.let { Instant.ofEpochMilli(it) })
     }
 
     fun importViaApi(sinceDate: Instant? = null) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsScreen.kt
@@ -30,6 +30,7 @@ import com.accbot.dca.data.local.NotificationType
 import com.accbot.dca.domain.model.AppNotification
 import com.accbot.dca.presentation.components.EmptyState
 import com.accbot.dca.presentation.ui.theme.Error
+import com.accbot.dca.presentation.ui.theme.LocalSandboxMode
 import com.accbot.dca.presentation.ui.theme.Warning
 import com.accbot.dca.presentation.ui.theme.successColor
 import com.accbot.dca.presentation.utils.DateFormatters
@@ -53,6 +54,14 @@ fun NotificationsScreen(
                     )
                 },
                 actions = {
+                    if (LocalSandboxMode.current) {
+                        IconButton(onClick = { viewModel.createTestNotifications() }) {
+                            Icon(
+                                imageVector = Icons.Default.BugReport,
+                                contentDescription = "Create test notifications"
+                            )
+                        }
+                    }
                     if (unreadCount > 0) {
                         TextButton(onClick = { viewModel.markAllAsRead() }) {
                             Text(stringResource(R.string.notifications_mark_all_read))

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsScreen.kt
@@ -45,6 +45,10 @@ import com.accbot.dca.presentation.ui.theme.accentColor
 import com.accbot.dca.presentation.ui.theme.successColor
 import com.accbot.dca.presentation.utils.NumberFormatters
 import java.math.BigDecimal
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -173,6 +177,16 @@ fun PlanDetailsScreen(
                     Text(stringResource(R.string.common_cancel))
                 }
             }
+        )
+    }
+
+    // Import configuration dialog
+    if (uiState.showImportDialog) {
+        ImportConfigDialog(
+            sinceMillis = uiState.importSinceMillis,
+            onSinceDateChanged = { viewModel.setImportSinceDate(it) },
+            onConfirm = { viewModel.confirmImport() },
+            onDismiss = { viewModel.dismissImportDialog() }
         )
     }
 
@@ -703,7 +717,7 @@ fun PlanDetailsScreen(
                     if (plan.exchange.supportsApiImport) {
                         item {
                             Card(
-                                onClick = { viewModel.importViaApi() },
+                                onClick = { viewModel.showImportDialog() },
                                 enabled = !uiState.isApiImporting,
                                 colors = CardDefaults.cardColors(
                                     containerColor = MaterialTheme.colorScheme.surface
@@ -890,4 +904,102 @@ internal fun PlanConfigRow(
             )
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImportConfigDialog(
+    sinceMillis: Long?,
+    onSinceDateChanged: (Long?) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+    val dateFormatter = remember {
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+    }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(initialSelectedDateMillis = sinceMillis)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    onSinceDateChanged(datePickerState.selectedDateMillis)
+                    showDatePicker = false
+                }) {
+                    Text(stringResource(R.string.common_done))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.import_api_title)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.import_api_from_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedCard(
+                    onClick = { showDatePicker = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = if (sinceMillis != null)
+                                dateFormatter.format(Instant.ofEpochMilli(sinceMillis))
+                            else
+                                stringResource(R.string.import_api_all_history),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        if (sinceMillis != null) {
+                            IconButton(
+                                onClick = { onSinceDateChanged(null) },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Clear,
+                                    contentDescription = stringResource(R.string.import_api_all_history),
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.CalendarMonth,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.import_api_start))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_cancel))
+            }
+        }
+    )
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsScreen.kt
@@ -45,10 +45,6 @@ import com.accbot.dca.presentation.ui.theme.accentColor
 import com.accbot.dca.presentation.ui.theme.successColor
 import com.accbot.dca.presentation.utils.NumberFormatters
 import java.math.BigDecimal
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -904,102 +900,4 @@ internal fun PlanConfigRow(
             )
         }
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ImportConfigDialog(
-    sinceMillis: Long?,
-    onSinceDateChanged: (Long?) -> Unit,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    var showDatePicker by remember { mutableStateOf(false) }
-    val dateFormatter = remember {
-        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
-    }
-
-    if (showDatePicker) {
-        val datePickerState = rememberDatePickerState(initialSelectedDateMillis = sinceMillis)
-        DatePickerDialog(
-            onDismissRequest = { showDatePicker = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    onSinceDateChanged(datePickerState.selectedDateMillis)
-                    showDatePicker = false
-                }) {
-                    Text(stringResource(R.string.common_done))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDatePicker = false }) {
-                    Text(stringResource(R.string.common_cancel))
-                }
-            }
-        ) {
-            DatePicker(state = datePickerState)
-        }
-    }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.import_api_title)) },
-        text = {
-            Column {
-                Text(stringResource(R.string.import_api_from_label),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Spacer(modifier = Modifier.height(4.dp))
-                OutlinedCard(
-                    onClick = { showDatePicker = true },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(12.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = if (sinceMillis != null)
-                                dateFormatter.format(Instant.ofEpochMilli(sinceMillis))
-                            else
-                                stringResource(R.string.import_api_all_history),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        if (sinceMillis != null) {
-                            IconButton(
-                                onClick = { onSinceDateChanged(null) },
-                                modifier = Modifier.size(24.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Clear,
-                                    contentDescription = stringResource(R.string.import_api_all_history),
-                                    modifier = Modifier.size(18.dp)
-                                )
-                            }
-                        } else {
-                            Icon(
-                                imageVector = Icons.Default.CalendarMonth,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.import_api_start))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.common_cancel))
-            }
-        }
-    )
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Instant
 import javax.inject.Inject
 
 @Immutable
@@ -48,7 +49,9 @@ data class PlanDetailsUiState(
     val isBalanceLoading: Boolean = false,
     val isApiImporting: Boolean = false,
     val apiImportProgress: String = "",
-    val apiImportResult: ApiImportResultState? = null
+    val apiImportResult: ApiImportResultState? = null,
+    val showImportDialog: Boolean = false,
+    val importSinceMillis: Long? = null
 )
 
 @HiltViewModel
@@ -240,7 +243,25 @@ class PlanDetailsViewModel @Inject constructor(
         }
     }
 
-    fun importViaApi() {
+    fun showImportDialog() {
+        _uiState.update { it.copy(showImportDialog = true, importSinceMillis = null) }
+    }
+
+    fun dismissImportDialog() {
+        _uiState.update { it.copy(showImportDialog = false) }
+    }
+
+    fun setImportSinceDate(millis: Long?) {
+        _uiState.update { it.copy(importSinceMillis = millis) }
+    }
+
+    fun confirmImport() {
+        _uiState.update { it.copy(showImportDialog = false) }
+        val sinceDate = _uiState.value.importSinceMillis?.let { Instant.ofEpochMilli(it) }
+        importViaApi(sinceDate)
+    }
+
+    fun importViaApi(sinceDate: Instant? = null) {
         val plan = _uiState.value.plan ?: return
         if (_uiState.value.isApiImporting) return
 
@@ -265,7 +286,8 @@ class PlanDetailsViewModel @Inject constructor(
                     planId = plan.id,
                     crypto = plan.crypto,
                     fiat = plan.fiat,
-                    exchange = plan.exchange
+                    exchange = plan.exchange,
+                    sinceDate = sinceDate
                 ).collect { progress ->
                     when (progress) {
                         is ApiImportProgress.Fetching -> {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/plans/PlanDetailsViewModel.kt
@@ -256,9 +256,9 @@ class PlanDetailsViewModel @Inject constructor(
     }
 
     fun confirmImport() {
+        val sinceMillis = _uiState.value.importSinceMillis
         _uiState.update { it.copy(showImportDialog = false) }
-        val sinceDate = _uiState.value.importSinceMillis?.let { Instant.ofEpochMilli(it) }
-        importViaApi(sinceDate)
+        importViaApi(sinceMillis?.let { Instant.ofEpochMilli(it) })
     }
 
     fun importViaApi(sinceDate: Instant? = null) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/ui/theme/Theme.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/ui/theme/Theme.kt
@@ -54,16 +54,28 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Primary,
-    onPrimary = OnPrimary,
-    secondary = Secondary,
-    onSecondary = OnSecondary,
-    background = Color(0xFFF5F5F5),
+    primary = Color(0xFF2E9B7B),
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFFC2EAD9),
+    onPrimaryContainer = Color(0xFF0A3A28),
+    secondary = Color(0xFF4A6E62),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFCDE8DD),
+    onSecondaryContainer = Color(0xFF06201A),
+    background = Color(0xFFF8FBF9),
     onBackground = Color(0xFF1A1A2E),
-    surface = Color.White,
+    surface = Color(0xFFEDF5F0),
     onSurface = Color(0xFF1A1A2E),
-    surfaceVariant = Color(0xFFE0E0E0),
-    onSurfaceVariant = Color(0xFF666666),
+    surfaceVariant = Color(0xFFD4E5DE),
+    onSurfaceVariant = Color(0xFF4A5D55),
+    surfaceTint = Color(0xFF2E9B7B),
+    outline = Color(0xFF8FA99E),
+    outlineVariant = Color(0xFFC0D5CB),
+    surfaceContainerLowest = Color(0xFFFAFCFB),
+    surfaceContainerLow = Color(0xFFF5FAF7),
+    surfaceContainer = Color(0xFFF0F6F2),
+    surfaceContainerHigh = Color(0xFFEAF2ED),
+    surfaceContainerHighest = Color(0xFFE4EDE8),
     error = Error,
     onError = Color.White
 )
@@ -86,16 +98,28 @@ private val SandboxDarkColorScheme = darkColorScheme(
 
 // Sandbox light color scheme (orange theme)
 private val SandboxLightColorScheme = lightColorScheme(
-    primary = SandboxPrimary,
-    onPrimary = OnPrimary,
-    secondary = Secondary,
-    onSecondary = OnSecondary,
-    background = Color(0xFFF5F5F5),
+    primary = Color(0xFFE68A00),
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFFFFDDB0),
+    onPrimaryContainer = Color(0xFF3D2600),
+    secondary = Color(0xFF6E5E50),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFF5E0CC),
+    onSecondaryContainer = Color(0xFF2A1B0C),
+    background = Color(0xFFFFFCF8),
     onBackground = Color(0xFF1A1A2E),
-    surface = Color.White,
+    surface = Color(0xFFF5EDE2),
     onSurface = Color(0xFF1A1A2E),
-    surfaceVariant = Color(0xFFE0E0E0),
-    onSurfaceVariant = Color(0xFF666666),
+    surfaceVariant = Color(0xFFF0DCC8),
+    onSurfaceVariant = Color(0xFF5C4E42),
+    surfaceTint = Color(0xFFE68A00),
+    outline = Color(0xFFA89585),
+    outlineVariant = Color(0xFFD4C4B4),
+    surfaceContainerLowest = Color(0xFFFFFCF8),
+    surfaceContainerLow = Color(0xFFFFF9F2),
+    surfaceContainer = Color(0xFFFFF4E8),
+    surfaceContainerHigh = Color(0xFFFFF0E0),
+    surfaceContainerHighest = Color(0xFFFFEBD8),
     error = Error,
     onError = Color.White
 )
@@ -118,7 +142,10 @@ fun AccBotTheme(
         SideEffect {
             val window = (view.context as Activity).window
             window.statusBarColor = colorScheme.background.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            window.navigationBarColor = colorScheme.background.toArgb()
+            val insetsController = WindowCompat.getInsetsController(window, view)
+            insetsController.isAppearanceLightStatusBars = !darkTheme
+            insetsController.isAppearanceLightNavigationBars = !darkTheme
         }
     }
 
@@ -135,15 +162,15 @@ fun AccBotTheme(
 // ============================================
 
 /**
- * Returns the appropriate accent/primary color based on sandbox mode.
+ * Returns the appropriate accent/primary color based on sandbox mode and light/dark theme.
  * Use this instead of hardcoded `Primary` constant.
  */
 @Composable
-fun accentColor(): Color = if (LocalSandboxMode.current) SandboxPrimary else Primary
+fun accentColor(): Color = MaterialTheme.colorScheme.primary
 
 /**
- * Returns the appropriate success color based on sandbox mode.
+ * Returns the appropriate success color based on sandbox mode and light/dark theme.
  * Use this instead of hardcoded `Success` constant.
  */
 @Composable
-fun successColor(): Color = if (LocalSandboxMode.current) SandboxSuccess else Success
+fun successColor(): Color = MaterialTheme.colorScheme.primary

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/ui/theme/Theme.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -170,7 +171,15 @@ fun accentColor(): Color = MaterialTheme.colorScheme.primary
 
 /**
  * Returns the appropriate success color based on sandbox mode and light/dark theme.
- * Use this instead of hardcoded `Success` constant.
+ * Distinct from accentColor() so success states (positive ROI, goals) are visually
+ * distinguishable from primary UI accents.
  */
 @Composable
-fun successColor(): Color = MaterialTheme.colorScheme.primary
+fun successColor(): Color = if (LocalSandboxMode.current) {
+    MaterialTheme.colorScheme.primary // Orange in sandbox
+} else {
+    if (MaterialTheme.colorScheme.background.luminance() > 0.5f)
+        Color(0xFF2E7D32) // Material Green 800 for light theme
+    else
+        Success // Original green for dark theme
+}

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -627,6 +627,10 @@
     <string name="import_api_no_new">Žádné nové transakce k importu</string>
     <string name="import_api_offer_title">Importovat historii transakcí?</string>
     <string name="import_api_offer_text">Chcete importovat existující historii transakcí z %1$s? Můžete to udělat i později v detailu burzy.</string>
+    <string name="import_api_dialog_text">Import historie obchodů pro %1$d plánů.</string>
+    <string name="import_api_from_label">Od</string>
+    <string name="import_api_all_history">Celá historie</string>
+    <string name="import_api_start">Importovat</string>
 
     <!-- Schedule Builder -->
     <string name="schedule_type_label">Typ rozvrhu</string>

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -57,7 +57,7 @@
     <string name="dashboard_refresh_prices">Obnovit ceny</string>
     <string name="dashboard_transactions_total">celkem %1$d transakcí</string>
     <string name="dashboard_invested">Investováno</string>
-    <string name="dashboard_avg_price">Prům. cena</string>
+    <string name="dashboard_avg_price">Prům. nák. cena</string>
     <string name="dashboard_current_price">Aktuální cena</string>
     <string name="dashboard_active_plans">Moje DCA plány</string>
     <string name="dashboard_next_prefix">Další: %1$s</string>
@@ -423,25 +423,25 @@
     <string name="strategy_purchase_tiers">Nákupní úrovně</string>
     <string name="strategy_distance_from_ath">Vzdálenost od ATH</string>
     <string name="strategy_multiplier">Násobitel</string>
-    <string name="strategy_ath_tier_0_10">0–10 % pod</string>
-    <string name="strategy_ath_tier_10_30">10–30 % pod</string>
-    <string name="strategy_ath_tier_30_50">30–50 % pod</string>
-    <string name="strategy_ath_tier_50_70">50–70 % pod</string>
-    <string name="strategy_ath_tier_70_plus">70 %+ pod</string>
+    <string name="strategy_ath_tier_0_20">0–20 %</string>
+    <string name="strategy_ath_tier_20_40">20–40 %</string>
+    <string name="strategy_ath_tier_40_60">40–60 %</string>
+    <string name="strategy_ath_tier_60_80">60–80 %</string>
+    <string name="strategy_ath_tier_80_100">80–100 %</string>
     <string name="strategy_ath_mult_50">0,5× (50 %)</string>
     <string name="strategy_ath_mult_100">1,0× (100 %)</string>
     <string name="strategy_ath_mult_150">1,5× (150 %)</string>
     <string name="strategy_ath_mult_200">2,0× (200 %)</string>
     <string name="strategy_ath_mult_300">3,0× (300 %)</string>
-    <string name="strategy_ath_example">Příklad: Se základní částkou 100 EUR, pokud je BTC 40 % pod ATH, nakoupíte za 150 EUR.</string>
+    <string name="strategy_ath_example">Příklad: Se základní částkou 100 EUR, pokud je BTC 50 % pod ATH, nakoupíte za 150 EUR.</string>
     <string name="strategy_fg_explanation">Tato strategie využívá index Fear &amp; Greed k úpravě nákupů. Kupujte více, když na trhu panuje strach (často dobrá příležitost), kupujte méně při extrémní chamtivosti.</string>
     <string name="strategy_sentiment_tiers">Úrovně sentimentu</string>
     <string name="strategy_market_sentiment">Tržní sentiment</string>
-    <string name="strategy_fg_extreme_fear">Extrémní strach (0–24)</string>
-    <string name="strategy_fg_fear">Strach (25–44)</string>
-    <string name="strategy_fg_neutral">Neutrální (45–54)</string>
-    <string name="strategy_fg_greed">Chamtivost (55–74)</string>
-    <string name="strategy_fg_extreme_greed">Extrémní chamtivost (75–100)</string>
+    <string name="strategy_fg_extreme_fear">Extrémní strach (0–19)</string>
+    <string name="strategy_fg_fear">Strach (20–39)</string>
+    <string name="strategy_fg_neutral">Neutrální (40–59)</string>
+    <string name="strategy_fg_greed">Chamtivost (60–79)</string>
+    <string name="strategy_fg_extreme_greed">Extrémní chamtivost (80–100)</string>
     <string name="strategy_fg_mult_250">2,5× (250 %)</string>
     <string name="strategy_fg_mult_150">1,5× (150 %)</string>
     <string name="strategy_fg_mult_100">1,0× (100 %)</string>
@@ -796,6 +796,23 @@
     <string name="plan_target_amount_description">Zobrazí progress bar na dashboardu pro vizualizaci cíle</string>
     <string name="dashboard_goal_progress">%1$s / %2$s %3$s (%4$s%%)</string>
     <string name="dashboard_goal_reached">Cíl dosažen!</string>
+
+    <!-- Market Pulse -->
+    <string name="dashboard_market_pulse">Tržní nálada</string>
+    <string name="dashboard_fear_greed">Fear &amp; Greed</string>
+    <string name="dashboard_fear_label">Strach</string>
+    <string name="dashboard_greed_label">Chamtivost</string>
+    <string name="dashboard_ath_distance">Vzdálenost od ATH</string>
+    <string name="fg_class_extreme_fear">Extrémní strach</string>
+    <string name="fg_class_fear">Strach</string>
+    <string name="fg_class_neutral">Neutrální</string>
+    <string name="fg_class_greed">Chamtivost</string>
+    <string name="fg_class_extreme_greed">Extrémní chamtivost</string>
+    <string name="dashboard_purchase_amount_formula">%1$s %2$s (%3$s × %4$s) • %5$s</string>
+
+    <!-- Settings: Market Pulse -->
+    <string name="settings_market_pulse_title">Tržní nálada</string>
+    <string name="settings_market_pulse_subtitle">Zobrazit tržní indikátory na přehledu</string>
 
     <!-- Accessibility -->
     <string name="a11y_retry">Opakovat</string>

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -647,6 +647,10 @@
     <string name="import_api_no_new">No new transactions to import</string>
     <string name="import_api_offer_title">Import Transaction History?</string>
     <string name="import_api_offer_text">Would you like to import your existing transaction history from %1$s? You can also do this later from the exchange detail screen.</string>
+    <string name="import_api_dialog_text">Import trade history for %1$d plans.</string>
+    <string name="import_api_from_label">From</string>
+    <string name="import_api_all_history">All history</string>
+    <string name="import_api_start">Import</string>
 
     <!-- Exchange Instructions - Coinmate -->
     <string name="exchange_instructions_coinmate_1">Go to coinmate.io and log in</string>

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="dashboard_refresh_prices">Refresh prices</string>
     <string name="dashboard_transactions_total">%1$d transactions total</string>
     <string name="dashboard_invested">Invested</string>
-    <string name="dashboard_avg_price">Avg Price</string>
+    <string name="dashboard_avg_price">Avg Buy Price</string>
     <string name="dashboard_current_price">Current Price</string>
     <string name="dashboard_active_plans">My DCA Plans</string>
     <string name="dashboard_next_prefix">Next: %1$s</string>
@@ -422,25 +422,25 @@
     <string name="strategy_purchase_tiers">Purchase Tiers</string>
     <string name="strategy_distance_from_ath">Distance from ATH</string>
     <string name="strategy_multiplier">Multiplier</string>
-    <string name="strategy_ath_tier_0_10">0-10% below</string>
-    <string name="strategy_ath_tier_10_30">10-30% below</string>
-    <string name="strategy_ath_tier_30_50">30-50% below</string>
-    <string name="strategy_ath_tier_50_70">50-70% below</string>
-    <string name="strategy_ath_tier_70_plus">70%+ below</string>
+    <string name="strategy_ath_tier_0_20">0–20%</string>
+    <string name="strategy_ath_tier_20_40">20–40%</string>
+    <string name="strategy_ath_tier_40_60">40–60%</string>
+    <string name="strategy_ath_tier_60_80">60–80%</string>
+    <string name="strategy_ath_tier_80_100">80–100%</string>
     <string name="strategy_ath_mult_50">0.5x (50%)</string>
     <string name="strategy_ath_mult_100">1.0x (100%)</string>
     <string name="strategy_ath_mult_150">1.5x (150%)</string>
     <string name="strategy_ath_mult_200">2.0x (200%)</string>
     <string name="strategy_ath_mult_300">3.0x (300%)</string>
-    <string name="strategy_ath_example">Example: With a base amount of 100 EUR, if BTC is 40% below ATH, you\'ll buy 150 EUR worth.</string>
+    <string name="strategy_ath_example">Example: With a base amount of 100 EUR, if BTC is 50% below ATH, you\'ll buy 150 EUR worth.</string>
     <string name="strategy_fg_explanation">This strategy uses the Fear &amp; Greed Index to adjust purchases. Buy more when the market is fearful (often a good opportunity), buy less during extreme greed.</string>
     <string name="strategy_sentiment_tiers">Sentiment Tiers</string>
     <string name="strategy_market_sentiment">Market Sentiment</string>
-    <string name="strategy_fg_extreme_fear">Extreme Fear (0-24)</string>
-    <string name="strategy_fg_fear">Fear (25-44)</string>
-    <string name="strategy_fg_neutral">Neutral (45-54)</string>
-    <string name="strategy_fg_greed">Greed (55-74)</string>
-    <string name="strategy_fg_extreme_greed">Extreme Greed (75-100)</string>
+    <string name="strategy_fg_extreme_fear">Extreme Fear (0–19)</string>
+    <string name="strategy_fg_fear">Fear (20–39)</string>
+    <string name="strategy_fg_neutral">Neutral (40–59)</string>
+    <string name="strategy_fg_greed">Greed (60–79)</string>
+    <string name="strategy_fg_extreme_greed">Extreme Greed (80–100)</string>
     <string name="strategy_fg_mult_250">2.5x (250%)</string>
     <string name="strategy_fg_mult_150">1.5x (150%)</string>
     <string name="strategy_fg_mult_100">1.0x (100%)</string>
@@ -791,6 +791,23 @@
     <string name="plan_target_amount_description">Shows a progress bar on the dashboard to visualize your goal</string>
     <string name="dashboard_goal_progress">%1$s / %2$s %3$s (%4$s%%)</string>
     <string name="dashboard_goal_reached">Goal reached!</string>
+
+    <!-- Market Pulse -->
+    <string name="dashboard_market_pulse">Market Pulse</string>
+    <string name="dashboard_fear_greed">Fear &amp; Greed</string>
+    <string name="dashboard_fear_label">Fear</string>
+    <string name="dashboard_greed_label">Greed</string>
+    <string name="dashboard_ath_distance">ATH Distance</string>
+    <string name="fg_class_extreme_fear">Extreme Fear</string>
+    <string name="fg_class_fear">Fear</string>
+    <string name="fg_class_neutral">Neutral</string>
+    <string name="fg_class_greed">Greed</string>
+    <string name="fg_class_extreme_greed">Extreme Greed</string>
+    <string name="dashboard_purchase_amount_formula">%1$s %2$s (%3$s × %4$s) • %5$s</string>
+
+    <!-- Settings: Market Pulse -->
+    <string name="settings_market_pulse_title">Market Pulse</string>
+    <string name="settings_market_pulse_subtitle">Show market indicators on dashboard</string>
 
     <!-- Accessibility -->
     <string name="a11y_retry">Retry</string>


### PR DESCRIPTION
## Summary
- **Light theme polish**: Improved colors, contrast, and chart axis labels for better readability in light mode
- **Market Pulse card**: Collapsible (tap to toggle) with persistent state; can be fully disabled from Settings
- **Chart improvements**: Adaptive aggregation (daily/weekly/monthly based on data range), avg buy price line, strategy labels in plan titles
- **Data fixes**: Stale ATH data after plan deletion, race condition between refresh and collectLatest, corrected F&G/ATH tier thresholds
- **Import improvements**: Date filter for API imports, import config dialog
- **Strategy info**: Fixed tier labels to match actual 20% code boundaries

## Test plan
- [ ] Toggle Market Pulse collapse on dashboard — state persists across restarts
- [ ] Disable Market Pulse in Settings → card hidden on dashboard; re-enable → reappears
- [ ] Delete a crypto plan → ATH data updates to only show remaining cryptos
- [ ] Pull-to-refresh repeatedly — KPI data should never flash/disappear
- [ ] Verify light theme colors and contrast across all screens
- [ ] Check chart aggregation switches correctly for different date ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)