### PR TITLE
Fix CI: remove PAT dependency from release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -4,14 +4,22 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_run:
+    workflows: ["Auto-release Tag"]
+    types: [completed]
 
 jobs:
   build:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -52,9 +60,17 @@ jobs:
           cd accbot-android
           ./gradlew bundleRelease
 
-      - name: Extract version from tag
+      - name: Extract version
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          else
+            MAJOR=$(grep "^VERSION_MAJOR=" accbot-android/gradle.properties | cut -d= -f2)
+            MINOR=$(grep "^VERSION_MINOR=" accbot-android/gradle.properties | cut -d= -f2)
+            PATCH=$(grep "^VERSION_PATCH=" accbot-android/gradle.properties | cut -d= -f2)
+            echo "VERSION=${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Rename artifacts with version
         run: |
@@ -98,6 +114,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: v${{ steps.version.outputs.VERSION }}
           name: AccBot Android v${{ steps.version.outputs.VERSION }}
           body: |
             ## AccBot Android v${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/auto-release-tag.yml
+++ b/.github/workflows/auto-release-tag.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     if: >
@@ -25,7 +28,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.PAT_GITHUB }}
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
## Summary
- `auto-release-tag.yml`: replace `secrets.PAT_GITHUB` with default `GITHUB_TOKEN` + `permissions: contents: write`
- `android-release.yml`: add `workflow_run` trigger so it fires after Auto-release Tag completes (GITHUB_TOKEN tag pushes don't trigger `on: push: tags`)
- Handle version extraction from `gradle.properties` for `workflow_run` events
- Add explicit `tag_name` to `softprops/action-gh-release`

## Why
The `PAT_GITHUB` secret doesn't exist, causing the auto-release-tag job to fail. This removes the PAT dependency entirely by chaining workflows via `workflow_run`.

## Flow after this change
```
PR merge (release/v*) → auto-release-tag (GITHUB_TOKEN)
                              ↓ workflow_run
                        android-release (build + GitHub Release)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)