### PR TITLE
Release v2.4.1 — Stability & CI Fixes

### DIFF
--- a/accbot-android/gradle.properties
+++ b/accbot-android/gradle.properties
@@ -9,7 +9,7 @@ android.nonTransitiveRClass=true
 # App versioning (semver)
 VERSION_MAJOR=2
 VERSION_MINOR=4
-VERSION_PATCH=0
+VERSION_PATCH=1
 
 # Screenshot testing
 android.experimental.enableScreenshotTest=true

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,25 @@
 [
   {
+    "versionCode": 24100,
+    "version": "2.4.1",
+    "title": {
+      "en": "Stability & CI Fixes",
+      "cs": "Opravy stability a CI"
+    },
+    "features": {
+      "en": [
+        "Fix R8 obfuscation breaking API JSON parsing in release builds",
+        "Smart ATH caching — reduces redundant network calls",
+        "CI pipeline fix — remove PAT dependency for release workflow"
+      ],
+      "cs": [
+        "Oprava R8 obfuskace narušující parsování API odpovědí v release buildech",
+        "Chytré cachování ATH dat — méně zbytečných síťových volání",
+        "Oprava CI pipeline — odstranění závislosti na PAT pro release workflow"
+      ]
+    }
+  },
+  {
     "versionCode": 24000,
     "version": "2.4.0",
     "title": {


### PR DESCRIPTION
## Summary
- Bump version to **2.4.1** (patch)
- Add changelog entry for v2.4.1

### What's included (since v2.4.0)
- Fix R8 obfuscation breaking API JSON parsing in release builds
- Smart ATH caching — reduces redundant network calls
- CI pipeline fix — remove PAT dependency for release workflow

## Release Flow
Merging this PR → `auto-release-tag` creates `v2.4.1` tag → `android-release` builds AAB/APK and creates GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)