### PR TITLE
Release v2.4.2 — Locale-Aware Notifications

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/BackupDataCollector.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/BackupDataCollector.kt
@@ -133,6 +133,7 @@ class BackupDataCollector @Inject constructor(
         exchange = exchange?.name,
         isRead = isRead,
         isArchived = isArchived,
+        templateArgs = templateArgs,
         createdAt = createdAt.toEpochMilli()
     )
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/BackupDataRestorer.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/BackupDataRestorer.kt
@@ -224,6 +224,7 @@ class BackupDataRestorer @Inject constructor(
         exchange = exchange?.let { try { Exchange.valueOf(it) } catch (_: Exception) { null } },
         isRead = isRead,
         isArchived = isArchived,
+        templateArgs = templateArgs,
         createdAt = Instant.ofEpochMilli(createdAt)
     )
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/DcaDatabase.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/DcaDatabase.kt
@@ -19,7 +19,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         NotificationEntity::class,
         WithdrawalThresholdEntity::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -179,6 +179,13 @@ abstract class DcaDatabase : RoomDatabase() {
             }
         }
 
+        // Migration from version 13 to 14: Add templateArgs column to notifications
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE notifications ADD COLUMN templateArgs TEXT DEFAULT NULL")
+            }
+        }
+
         // Migration from version 9 to 10: Add notifications and withdrawal_thresholds tables
         private val MIGRATION_9_10 = object : Migration(9, 10) {
             override fun migrate(database: SupportSQLiteDatabase) {
@@ -281,7 +288,7 @@ abstract class DcaDatabase : RoomDatabase() {
                 DcaDatabase::class.java,
                 databaseName
             )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
                 // Only allow destructive migration on app downgrade, never on failed upgrade
                 // This protects user's transaction history from accidental deletion
                 .fallbackToDestructiveMigrationOnDowngrade()

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/Entities.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/Entities.kt
@@ -274,6 +274,7 @@ data class NotificationEntity(
     val isRead: Boolean = false,
     val isArchived: Boolean = false,
     val systemNotificationId: Int? = null,
+    val templateArgs: String? = null,
     val createdAt: Instant = Instant.now()
 )
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/NotificationTemplateArgs.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/NotificationTemplateArgs.kt
@@ -1,0 +1,175 @@
+package com.accbot.dca.data.local
+
+import org.json.JSONObject
+
+/**
+ * Structured arguments for notification templates.
+ * Stored as JSON in the `templateArgs` column — text is rendered at display time
+ * using the current locale, so language switches re-render old notifications.
+ *
+ * Numbers are stored as raw strings (BigDecimal.toPlainString()) and formatted
+ * via NumberFormatters at render time.
+ */
+sealed class NotificationTemplateArgs {
+
+    abstract fun toJson(): String
+
+    /** Successful purchase (filled immediately). */
+    data class Purchase(
+        val cryptoAmount: String,
+        val crypto: String,
+        val fiatAmount: String,
+        val fiat: String,
+        val price: String
+    ) : NotificationTemplateArgs() {
+        override fun toJson(): String = JSONObject().apply {
+            put(KEY_TYPE, TYPE_PURCHASE)
+            put("cryptoAmount", cryptoAmount)
+            put("crypto", crypto)
+            put("fiatAmount", fiatAmount)
+            put("fiat", fiat)
+            put("price", price)
+        }.toString()
+    }
+
+    /** Purchase submitted but awaiting confirmation (PENDING status). */
+    data class PurchasePending(
+        val fiatAmount: String,
+        val fiat: String,
+        val crypto: String,
+        val price: String
+    ) : NotificationTemplateArgs() {
+        override fun toJson(): String = JSONObject().apply {
+            put(KEY_TYPE, TYPE_PURCHASE_PENDING)
+            put("fiatAmount", fiatAmount)
+            put("fiat", fiat)
+            put("crypto", crypto)
+            put("price", price)
+        }.toString()
+    }
+
+    /** DCA error with structured crypto + errorMessage. */
+    data class Error(
+        val crypto: String,
+        val errorMessage: String
+    ) : NotificationTemplateArgs() {
+        override fun toJson(): String = JSONObject().apply {
+            put(KEY_TYPE, TYPE_ERROR)
+            put("crypto", crypto)
+            put("errorMessage", errorMessage)
+        }.toString()
+    }
+
+    /** Low fiat balance warning. */
+    data class LowBalance(
+        val exchangeName: String,
+        val fiat: String,
+        val remainingDays: Double
+    ) : NotificationTemplateArgs() {
+        override fun toJson(): String = JSONObject().apply {
+            put(KEY_TYPE, TYPE_LOW_BALANCE)
+            put("exchangeName", exchangeName)
+            put("fiat", fiat)
+            put("remainingDays", remainingDays)
+        }.toString()
+    }
+
+    /** Withdrawal threshold reached. */
+    data class WithdrawalThreshold(
+        val amount: String,
+        val crypto: String,
+        val exchangeName: String
+    ) : NotificationTemplateArgs() {
+        override fun toJson(): String = JSONObject().apply {
+            put(KEY_TYPE, TYPE_WITHDRAWAL_THRESHOLD)
+            put("amount", amount)
+            put("crypto", crypto)
+            put("exchangeName", exchangeName)
+        }.toString()
+    }
+
+    /** Target accumulation reached — plan auto-disabled. */
+    data class TargetReached(
+        val targetAmount: String,
+        val crypto: String
+    ) : NotificationTemplateArgs() {
+        override fun toJson(): String = JSONObject().apply {
+            put(KEY_TYPE, TYPE_TARGET_REACHED)
+            put("targetAmount", targetAmount)
+            put("crypto", crypto)
+        }.toString()
+    }
+
+    /** Purchase amount below exchange minimum order size. */
+    data class BelowMinimum(
+        val crypto: String,
+        val purchaseAmount: String,
+        val fiat: String,
+        val minOrderSize: String
+    ) : NotificationTemplateArgs() {
+        override fun toJson(): String = JSONObject().apply {
+            put(KEY_TYPE, TYPE_BELOW_MINIMUM)
+            put("crypto", crypto)
+            put("purchaseAmount", purchaseAmount)
+            put("fiat", fiat)
+            put("minOrderSize", minOrderSize)
+        }.toString()
+    }
+
+    companion object {
+        private const val KEY_TYPE = "type"
+        private const val TYPE_PURCHASE = "purchase"
+        private const val TYPE_PURCHASE_PENDING = "purchase_pending"
+        private const val TYPE_ERROR = "error"
+        private const val TYPE_LOW_BALANCE = "low_balance"
+        private const val TYPE_WITHDRAWAL_THRESHOLD = "withdrawal_threshold"
+        private const val TYPE_TARGET_REACHED = "target_reached"
+        private const val TYPE_BELOW_MINIMUM = "below_minimum"
+
+        fun fromJson(json: String): NotificationTemplateArgs? = try {
+            val obj = JSONObject(json)
+            when (obj.getString(KEY_TYPE)) {
+                TYPE_PURCHASE -> Purchase(
+                    cryptoAmount = obj.getString("cryptoAmount"),
+                    crypto = obj.getString("crypto"),
+                    fiatAmount = obj.getString("fiatAmount"),
+                    fiat = obj.getString("fiat"),
+                    price = obj.getString("price")
+                )
+                TYPE_PURCHASE_PENDING -> PurchasePending(
+                    fiatAmount = obj.getString("fiatAmount"),
+                    fiat = obj.getString("fiat"),
+                    crypto = obj.getString("crypto"),
+                    price = obj.getString("price")
+                )
+                TYPE_ERROR -> Error(
+                    crypto = obj.getString("crypto"),
+                    errorMessage = obj.getString("errorMessage")
+                )
+                TYPE_LOW_BALANCE -> LowBalance(
+                    exchangeName = obj.getString("exchangeName"),
+                    fiat = obj.getString("fiat"),
+                    remainingDays = obj.getDouble("remainingDays")
+                )
+                TYPE_WITHDRAWAL_THRESHOLD -> WithdrawalThreshold(
+                    amount = obj.getString("amount"),
+                    crypto = obj.getString("crypto"),
+                    exchangeName = obj.getString("exchangeName")
+                )
+                TYPE_TARGET_REACHED -> TargetReached(
+                    targetAmount = obj.getString("targetAmount"),
+                    crypto = obj.getString("crypto")
+                )
+                TYPE_BELOW_MINIMUM -> BelowMinimum(
+                    crypto = obj.getString("crypto"),
+                    purchaseAmount = obj.getString("purchaseAmount"),
+                    fiat = obj.getString("fiat"),
+                    minOrderSize = obj.getString("minOrderSize")
+                )
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/model/BackupModels.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/model/BackupModels.kt
@@ -116,6 +116,7 @@ data class BackupNotification(
     val exchange: String? = null,
     val isRead: Boolean = false,
     val isArchived: Boolean = false,
+    val templateArgs: String? = null,
     val createdAt: Long = 0
 )
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationRenderer.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationRenderer.kt
@@ -1,0 +1,108 @@
+package com.accbot.dca.presentation.screens.notifications
+
+import android.content.Context
+import com.accbot.dca.R
+import com.accbot.dca.data.local.NotificationEntity
+import com.accbot.dca.data.local.NotificationTemplateArgs
+import com.accbot.dca.presentation.utils.NumberFormatters
+import java.math.BigDecimal
+
+/**
+ * Renders notification title/message from structured [NotificationTemplateArgs]
+ * using the current locale. Falls back to the pre-rendered text stored in the entity
+ * when templateArgs is null (legacy notifications).
+ */
+object NotificationRenderer {
+
+    /**
+     * @return Pair(title, message) rendered in the current locale.
+     */
+    fun render(context: Context, entity: NotificationEntity): Pair<String, String> {
+        val args = entity.templateArgs?.let { NotificationTemplateArgs.fromJson(it) }
+            ?: return entity.title to entity.message
+
+        return when (args) {
+            is NotificationTemplateArgs.Purchase -> {
+                val title = context.getString(R.string.notification_purchase_title)
+                val message = context.getString(
+                    R.string.notification_purchase_text,
+                    NumberFormatters.crypto(BigDecimal(args.cryptoAmount)),
+                    args.crypto,
+                    NumberFormatters.fiat(BigDecimal(args.fiatAmount)),
+                    args.fiat,
+                    NumberFormatters.fiat(BigDecimal(args.price))
+                )
+                title to message
+            }
+
+            is NotificationTemplateArgs.PurchasePending -> {
+                val title = context.getString(R.string.notification_purchase_title)
+                val message = context.getString(
+                    R.string.notification_purchase_pending_text,
+                    NumberFormatters.fiat(BigDecimal(args.fiatAmount)),
+                    args.fiat,
+                    args.crypto,
+                    NumberFormatters.fiat(BigDecimal(args.price))
+                )
+                title to message
+            }
+
+            is NotificationTemplateArgs.Error -> {
+                val title = context.getString(R.string.notification_dca_failed)
+                val message = context.getString(
+                    R.string.notification_dca_failed_text,
+                    args.crypto,
+                    args.errorMessage
+                )
+                title to message
+            }
+
+            is NotificationTemplateArgs.LowBalance -> {
+                val title = context.getString(R.string.notification_low_balance_title, args.exchangeName)
+                val daysText = if (args.remainingDays < 1) {
+                    context.getString(R.string.notification_low_balance_less_1_day)
+                } else {
+                    context.getString(R.string.notification_low_balance_days, args.remainingDays.toInt())
+                }
+                val message = context.getString(R.string.notification_low_balance_text, daysText, args.fiat)
+                title to message
+            }
+
+            is NotificationTemplateArgs.WithdrawalThreshold -> {
+                val title = context.getString(R.string.notification_withdrawal_threshold_title)
+                val message = context.getString(
+                    R.string.notification_withdrawal_threshold_text,
+                    args.amount,
+                    args.crypto,
+                    args.exchangeName
+                )
+                title to message
+            }
+
+            is NotificationTemplateArgs.TargetReached -> {
+                val title = context.getString(R.string.notification_dca_failed)
+                val message = context.getString(
+                    R.string.notification_target_reached,
+                    args.targetAmount,
+                    args.crypto
+                )
+                title to message
+            }
+
+            is NotificationTemplateArgs.BelowMinimum -> {
+                val title = context.getString(R.string.notification_dca_failed)
+                val message = context.getString(
+                    R.string.notification_dca_failed_text,
+                    args.crypto,
+                    context.getString(
+                        R.string.notification_below_minimum,
+                        args.purchaseAmount,
+                        args.fiat,
+                        args.minOrderSize
+                    )
+                )
+                title to message
+            }
+        }
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationRenderer.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationRenderer.kt
@@ -20,7 +20,10 @@ object NotificationRenderer {
     fun render(context: Context, entity: NotificationEntity): Pair<String, String> {
         val args = entity.templateArgs?.let { NotificationTemplateArgs.fromJson(it) }
             ?: return entity.title to entity.message
+        return render(context, args)
+    }
 
+    fun render(context: Context, args: NotificationTemplateArgs): Pair<String, String> {
         return when (args) {
             is NotificationTemplateArgs.Purchase -> {
                 val title = context.getString(R.string.notification_purchase_title)

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsScreen.kt
@@ -40,6 +40,8 @@ import com.accbot.dca.presentation.utils.DateFormatters
 fun NotificationsScreen(
     viewModel: NotificationsViewModel = hiltViewModel()
 ) {
+    LaunchedEffect(Unit) { viewModel.refreshForLocale() }
+
     val notifications by viewModel.notifications.collectAsStateWithLifecycle()
     val unreadCount by viewModel.unreadCount.collectAsStateWithLifecycle()
     var showDeleteAllDialog by remember { mutableStateOf(false) }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsViewModel.kt
@@ -1,5 +1,8 @@
 package com.accbot.dca.presentation.screens.notifications
 
+import android.content.Context
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.accbot.dca.data.local.NotificationDao
@@ -7,20 +10,47 @@ import com.accbot.dca.data.local.toDomain
 import com.accbot.dca.domain.model.AppNotification
 import com.accbot.dca.service.NotificationService
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import com.accbot.dca.data.local.NotificationTemplateArgs
 import java.math.BigDecimal
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
 class NotificationsViewModel @Inject constructor(
     private val notificationDao: NotificationDao,
-    private val notificationService: NotificationService
+    private val notificationService: NotificationService,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
-    val notifications: StateFlow<List<AppNotification>> = notificationDao.getActiveNotifications()
-        .map { entities -> entities.map { it.toDomain() } }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    private val _localeTrigger = MutableStateFlow(0L)
+
+    val notifications: StateFlow<List<AppNotification>> = combine(
+        notificationDao.getActiveNotifications(),
+        _localeTrigger
+    ) { entities, _ ->
+        val localeContext = createLocaleAwareContext()
+        entities.map { entity ->
+            val (title, message) = NotificationRenderer.render(localeContext, entity)
+            entity.toDomain().copy(title = title, message = message)
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun refreshForLocale() {
+        _localeTrigger.value++
+    }
+
+    private fun createLocaleAwareContext(): Context {
+        val appLocales = AppCompatDelegate.getApplicationLocales()
+        if (appLocales.isEmpty) return context
+        val locale = appLocales[0] ?: return context
+        val config = Configuration(context.resources.configuration).apply {
+            setLocale(locale)
+        }
+        return context.createConfigurationContext(config)
+    }
 
     val unreadCount: StateFlow<Int> = notificationDao.getUnreadCount()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
@@ -70,9 +100,13 @@ class NotificationsViewModel @Inject constructor(
                 planId = 901
             )
             notificationService.showErrorNotification(
-                title = "DCA Failed",
-                message = "Insufficient balance on Binance for BTC/EUR",
-                planId = 902
+                title = context.getString(com.accbot.dca.R.string.notification_dca_failed),
+                message = context.getString(com.accbot.dca.R.string.notification_dca_failed_text, "BTC", "Insufficient balance on Binance"),
+                planId = 902,
+                templateArgs = NotificationTemplateArgs.Error(
+                    crypto = "BTC",
+                    errorMessage = "Insufficient balance on Binance"
+                )
             )
             notificationService.showLowBalanceNotification(
                 exchange = "Binance",
@@ -86,6 +120,29 @@ class NotificationsViewModel @Inject constructor(
                 amount = BigDecimal("0.01"),
                 threshold = BigDecimal("0.01"),
                 planId = 904
+            )
+            // Target reached
+            notificationService.showErrorNotification(
+                title = context.getString(com.accbot.dca.R.string.notification_dca_failed),
+                message = context.getString(com.accbot.dca.R.string.notification_target_reached, "0.5", "BTC"),
+                planId = 905,
+                templateArgs = NotificationTemplateArgs.TargetReached(
+                    targetAmount = "0.5",
+                    crypto = "BTC"
+                )
+            )
+            // Below minimum
+            notificationService.showErrorNotification(
+                title = context.getString(com.accbot.dca.R.string.notification_dca_failed),
+                message = context.getString(com.accbot.dca.R.string.notification_dca_failed_text, "BTC",
+                    context.getString(com.accbot.dca.R.string.notification_below_minimum, "5", "EUR", "10")),
+                planId = 906,
+                templateArgs = NotificationTemplateArgs.BelowMinimum(
+                    crypto = "BTC",
+                    purchaseAmount = "5",
+                    fiat = "EUR",
+                    minOrderSize = "10"
+                )
             )
         }
     }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/notifications/NotificationsViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import com.accbot.dca.data.local.NotificationTemplateArgs
 import java.math.BigDecimal
-import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -100,8 +99,6 @@ class NotificationsViewModel @Inject constructor(
                 planId = 901
             )
             notificationService.showErrorNotification(
-                title = context.getString(com.accbot.dca.R.string.notification_dca_failed),
-                message = context.getString(com.accbot.dca.R.string.notification_dca_failed_text, "BTC", "Insufficient balance on Binance"),
                 planId = 902,
                 templateArgs = NotificationTemplateArgs.Error(
                     crypto = "BTC",
@@ -123,8 +120,6 @@ class NotificationsViewModel @Inject constructor(
             )
             // Target reached
             notificationService.showErrorNotification(
-                title = context.getString(com.accbot.dca.R.string.notification_dca_failed),
-                message = context.getString(com.accbot.dca.R.string.notification_target_reached, "0.5", "BTC"),
                 planId = 905,
                 templateArgs = NotificationTemplateArgs.TargetReached(
                     targetAmount = "0.5",
@@ -133,9 +128,6 @@ class NotificationsViewModel @Inject constructor(
             )
             // Below minimum
             notificationService.showErrorNotification(
-                title = context.getString(com.accbot.dca.R.string.notification_dca_failed),
-                message = context.getString(com.accbot.dca.R.string.notification_dca_failed_text, "BTC",
-                    context.getString(com.accbot.dca.R.string.notification_below_minimum, "5", "EUR", "10")),
                 planId = 906,
                 templateArgs = NotificationTemplateArgs.BelowMinimum(
                     crypto = "BTC",

--- a/accbot-android/app/src/main/java/com/accbot/dca/service/NotificationService.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/service/NotificationService.kt
@@ -11,6 +11,7 @@ import com.accbot.dca.MainActivity
 import com.accbot.dca.R
 import com.accbot.dca.data.local.NotificationDao
 import com.accbot.dca.data.local.NotificationEntity
+import com.accbot.dca.data.local.NotificationTemplateArgs
 import com.accbot.dca.data.local.NotificationType
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.presentation.utils.NumberFormatters
@@ -123,6 +124,23 @@ class NotificationService @Inject constructor(
             context.getString(R.string.notification_purchase_text, NumberFormatters.crypto(cryptoAmount), crypto, NumberFormatters.fiat(fiatAmount), fiat, priceFormatted)
         }
 
+        val args = if (pending) {
+            NotificationTemplateArgs.PurchasePending(
+                fiatAmount = fiatAmount.toPlainString(),
+                fiat = fiat,
+                crypto = crypto,
+                price = price.toPlainString()
+            )
+        } else {
+            NotificationTemplateArgs.Purchase(
+                cryptoAmount = cryptoAmount.toPlainString(),
+                crypto = crypto,
+                fiatAmount = fiatAmount.toPlainString(),
+                fiat = fiat,
+                price = price.toPlainString()
+            )
+        }
+
         val sysNotifId = notificationIdForPlan(NOTIFICATION_ID_PURCHASE, planId)
         persistAndShow(
             sysNotifId = sysNotifId,
@@ -136,7 +154,8 @@ class NotificationService @Inject constructor(
                 planId = planId.takeIf { it > 0 },
                 crypto = crypto,
                 exchange = exchange,
-                systemNotificationId = sysNotifId
+                systemNotificationId = sysNotifId,
+                templateArgs = args.toJson()
             )
         )
     }
@@ -145,7 +164,14 @@ class NotificationService @Inject constructor(
      * Show error notification.
      * Uses a unique notification ID per plan so multiple error notifications are all visible.
      */
-    fun showErrorNotification(title: String, message: String, planId: Long = 0, exchange: Exchange? = null, crypto: String? = null) {
+    fun showErrorNotification(
+        title: String,
+        message: String,
+        planId: Long = 0,
+        exchange: Exchange? = null,
+        crypto: String? = null,
+        templateArgs: NotificationTemplateArgs? = null
+    ) {
         val sysNotifId = notificationIdForPlan(NOTIFICATION_ID_ERROR, planId)
         persistAndShow(
             sysNotifId = sysNotifId,
@@ -159,7 +185,8 @@ class NotificationService @Inject constructor(
                 planId = planId.takeIf { it > 0 },
                 crypto = crypto,
                 exchange = exchange,
-                systemNotificationId = sysNotifId
+                systemNotificationId = sysNotifId,
+                templateArgs = templateArgs?.toJson()
             )
         )
     }
@@ -172,6 +199,11 @@ class NotificationService @Inject constructor(
         val title = context.getString(R.string.notification_low_balance_title, exchange)
         val daysText = if (remainingDays < 1) context.getString(R.string.notification_low_balance_less_1_day) else context.getString(R.string.notification_low_balance_days, remainingDays.toInt())
         val text = context.getString(R.string.notification_low_balance_text, daysText, fiat)
+        val args = NotificationTemplateArgs.LowBalance(
+            exchangeName = exchange,
+            fiat = fiat,
+            remainingDays = remainingDays
+        )
         val sysNotifId = notificationIdForPlan(NOTIFICATION_ID_LOW_BALANCE, planId)
         persistAndShow(
             sysNotifId = sysNotifId,
@@ -183,7 +215,8 @@ class NotificationService @Inject constructor(
                 title = title,
                 message = text,
                 planId = planId.takeIf { it > 0 },
-                systemNotificationId = sysNotifId
+                systemNotificationId = sysNotifId,
+                templateArgs = args.toJson()
             )
         )
     }
@@ -200,6 +233,11 @@ class NotificationService @Inject constructor(
     ) {
         val title = context.getString(R.string.notification_withdrawal_threshold_title)
         val text = context.getString(R.string.notification_withdrawal_threshold_text, amount.toPlainString(), crypto, exchange)
+        val args = NotificationTemplateArgs.WithdrawalThreshold(
+            amount = amount.toPlainString(),
+            crypto = crypto,
+            exchangeName = exchange
+        )
         val sysNotifId = notificationIdForPlan(NOTIFICATION_ID_WITHDRAWAL_THRESHOLD, planId)
         persistAndShow(
             sysNotifId = sysNotifId,
@@ -212,7 +250,8 @@ class NotificationService @Inject constructor(
                 message = text,
                 planId = planId.takeIf { it > 0 },
                 crypto = crypto,
-                systemNotificationId = sysNotifId
+                systemNotificationId = sysNotifId,
+                templateArgs = args.toJson()
             )
         )
     }

--- a/accbot-android/app/src/main/java/com/accbot/dca/service/NotificationService.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/service/NotificationService.kt
@@ -13,6 +13,7 @@ import com.accbot.dca.data.local.NotificationDao
 import com.accbot.dca.data.local.NotificationEntity
 import com.accbot.dca.data.local.NotificationTemplateArgs
 import com.accbot.dca.data.local.NotificationType
+import com.accbot.dca.presentation.screens.notifications.NotificationRenderer
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.presentation.utils.NumberFormatters
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -165,23 +166,28 @@ class NotificationService @Inject constructor(
      * Uses a unique notification ID per plan so multiple error notifications are all visible.
      */
     fun showErrorNotification(
-        title: String,
-        message: String,
+        title: String? = null,
+        message: String? = null,
         planId: Long = 0,
         exchange: Exchange? = null,
         crypto: String? = null,
         templateArgs: NotificationTemplateArgs? = null
     ) {
+        val (t, m) = if (templateArgs != null) {
+            NotificationRenderer.render(context, templateArgs)
+        } else {
+            (title ?: "") to (message ?: "")
+        }
         val sysNotifId = notificationIdForPlan(NOTIFICATION_ID_ERROR, planId)
         persistAndShow(
             sysNotifId = sysNotifId,
             channel = CHANNEL_ERROR,
-            title = title,
-            text = message,
+            title = t,
+            text = m,
             entity = NotificationEntity(
                 type = NotificationType.ERROR,
-                title = title,
-                message = message,
+                title = t,
+                message = m,
                 planId = planId.takeIf { it > 0 },
                 crypto = crypto,
                 exchange = exchange,

--- a/accbot-android/app/src/main/java/com/accbot/dca/worker/DcaWorker.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/worker/DcaWorker.kt
@@ -6,6 +6,7 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.*
 import com.accbot.dca.data.local.DcaDatabase
 import com.accbot.dca.data.local.CredentialsStore
+import com.accbot.dca.data.local.NotificationTemplateArgs
 import com.accbot.dca.data.local.DcaPlanEntity
 import com.accbot.dca.data.local.TransactionEntity
 import com.accbot.dca.data.local.UserPreferences
@@ -88,10 +89,15 @@ class DcaWorker @AssistedInject constructor(
                     if (accumulated >= plan.targetAmount) {
                         database.dcaPlanDao().setEnabled(plan.id, false)
                         Log.d(TAG, "Plan ${plan.id} reached target ${plan.targetAmount}, auto-disabled")
+                        val targetArgs = NotificationTemplateArgs.TargetReached(
+                            targetAmount = plan.targetAmount.toPlainString(),
+                            crypto = plan.crypto
+                        )
                         notificationService.showErrorNotification(
                             context.getString(R.string.notification_dca_failed),
-                            "Target reached: ${plan.targetAmount} ${plan.crypto}",
-                            plan.id
+                            context.getString(R.string.notification_target_reached, plan.targetAmount.toPlainString(), plan.crypto),
+                            plan.id,
+                            templateArgs = targetArgs
                         )
                         continue
                     }
@@ -146,11 +152,18 @@ class DcaWorker @AssistedInject constructor(
                         Log.e(TAG, "Failed to save below-minimum transaction for plan ${plan.id}", e)
                     }
 
+                    val belowMinArgs = NotificationTemplateArgs.BelowMinimum(
+                        crypto = plan.crypto,
+                        purchaseAmount = purchaseAmount.toPlainString(),
+                        fiat = plan.fiat,
+                        minOrderSize = minOrderSize.toPlainString()
+                    )
                     notificationService.showErrorNotification(
                         context.getString(R.string.notification_dca_failed),
                         context.getString(R.string.notification_dca_failed_text, plan.crypto,
-                            "Amount $purchaseAmount ${plan.fiat} below exchange minimum $minOrderSize ${plan.fiat}"),
-                        plan.id
+                            context.getString(R.string.notification_below_minimum, purchaseAmount.toPlainString(), plan.fiat, minOrderSize.toPlainString())),
+                        plan.id,
+                        templateArgs = belowMinArgs
                     )
                     continue
                 }
@@ -303,10 +316,15 @@ class DcaWorker @AssistedInject constructor(
                                 Log.e(TAG, "Failed to save failed transaction for plan ${plan.id}", e)
                             }
 
+                            val errorArgs = NotificationTemplateArgs.Error(
+                                crypto = plan.crypto,
+                                errorMessage = finalResult.message
+                            )
                             notificationService.showErrorNotification(
                                 context.getString(R.string.notification_dca_failed),
                                 context.getString(R.string.notification_dca_failed_text, plan.crypto, finalResult.message),
-                                plan.id
+                                plan.id,
+                                templateArgs = errorArgs
                             )
                             Log.e(TAG, "DCA purchase failed for plan ${plan.id} after $maxAttempts attempts: ${finalResult.message}")
                         }

--- a/accbot-android/app/src/main/java/com/accbot/dca/worker/DcaWorker.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/worker/DcaWorker.kt
@@ -89,15 +89,12 @@ class DcaWorker @AssistedInject constructor(
                     if (accumulated >= plan.targetAmount) {
                         database.dcaPlanDao().setEnabled(plan.id, false)
                         Log.d(TAG, "Plan ${plan.id} reached target ${plan.targetAmount}, auto-disabled")
-                        val targetArgs = NotificationTemplateArgs.TargetReached(
-                            targetAmount = plan.targetAmount.toPlainString(),
-                            crypto = plan.crypto
-                        )
                         notificationService.showErrorNotification(
-                            context.getString(R.string.notification_dca_failed),
-                            context.getString(R.string.notification_target_reached, plan.targetAmount.toPlainString(), plan.crypto),
-                            plan.id,
-                            templateArgs = targetArgs
+                            planId = plan.id,
+                            templateArgs = NotificationTemplateArgs.TargetReached(
+                                targetAmount = plan.targetAmount.toPlainString(),
+                                crypto = plan.crypto
+                            )
                         )
                         continue
                     }
@@ -152,18 +149,14 @@ class DcaWorker @AssistedInject constructor(
                         Log.e(TAG, "Failed to save below-minimum transaction for plan ${plan.id}", e)
                     }
 
-                    val belowMinArgs = NotificationTemplateArgs.BelowMinimum(
-                        crypto = plan.crypto,
-                        purchaseAmount = purchaseAmount.toPlainString(),
-                        fiat = plan.fiat,
-                        minOrderSize = minOrderSize.toPlainString()
-                    )
                     notificationService.showErrorNotification(
-                        context.getString(R.string.notification_dca_failed),
-                        context.getString(R.string.notification_dca_failed_text, plan.crypto,
-                            context.getString(R.string.notification_below_minimum, purchaseAmount.toPlainString(), plan.fiat, minOrderSize.toPlainString())),
-                        plan.id,
-                        templateArgs = belowMinArgs
+                        planId = plan.id,
+                        templateArgs = NotificationTemplateArgs.BelowMinimum(
+                            crypto = plan.crypto,
+                            purchaseAmount = purchaseAmount.toPlainString(),
+                            fiat = plan.fiat,
+                            minOrderSize = minOrderSize.toPlainString()
+                        )
                     )
                     continue
                 }
@@ -316,15 +309,12 @@ class DcaWorker @AssistedInject constructor(
                                 Log.e(TAG, "Failed to save failed transaction for plan ${plan.id}", e)
                             }
 
-                            val errorArgs = NotificationTemplateArgs.Error(
-                                crypto = plan.crypto,
-                                errorMessage = finalResult.message
-                            )
                             notificationService.showErrorNotification(
-                                context.getString(R.string.notification_dca_failed),
-                                context.getString(R.string.notification_dca_failed_text, plan.crypto, finalResult.message),
-                                plan.id,
-                                templateArgs = errorArgs
+                                planId = plan.id,
+                                templateArgs = NotificationTemplateArgs.Error(
+                                    crypto = plan.crypto,
+                                    errorMessage = finalResult.message
+                                )
                             )
                             Log.e(TAG, "DCA purchase failed for plan ${plan.id} after $maxAttempts attempts: ${finalResult.message}")
                         }

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -725,6 +725,8 @@
     <string name="settings_withdrawal_threshold_no_plans">Žádné aktivní DCA plány</string>
     <string name="notification_withdrawal_threshold_title">Doporučen výběr</string>
     <string name="notification_withdrawal_threshold_text">Nakumulovali jste %1$s %2$s na %3$s — zvažte výběr do cold wallet</string>
+    <string name="notification_target_reached">Cíl dosažen: %1$s %2$s — plán automaticky deaktivován</string>
+    <string name="notification_below_minimum">Částka %1$s %2$s pod minimem burzy %3$s %2$s</string>
     <string name="dashboard_withdrawal_ready">%1$s %2$s na burze — zvažte výběr</string>
 
     <!-- DCA Alerts section -->

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -723,6 +723,8 @@
     <string name="settings_withdrawal_threshold_no_plans">No active DCA plans found</string>
     <string name="notification_withdrawal_threshold_title">Withdrawal Recommended</string>
     <string name="notification_withdrawal_threshold_text">You have accumulated %1$s %2$s on %3$s — consider withdrawing to cold wallet</string>
+    <string name="notification_target_reached">Target reached: %1$s %2$s — plan auto-disabled</string>
+    <string name="notification_below_minimum">Amount %1$s %2$s below exchange minimum %3$s %2$s</string>
     <string name="dashboard_withdrawal_ready">%1$s %2$s on exchange — consider withdrawal</string>
 
     <!-- DCA Alerts section -->

--- a/accbot-android/gradle.properties
+++ b/accbot-android/gradle.properties
@@ -9,7 +9,7 @@ android.nonTransitiveRClass=true
 # App versioning (semver)
 VERSION_MAJOR=2
 VERSION_MINOR=4
-VERSION_PATCH=1
+VERSION_PATCH=2
 
 # Screenshot testing
 android.experimental.enableScreenshotTest=true

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,25 @@
 [
   {
+    "versionCode": 24200,
+    "version": "2.4.2",
+    "title": {
+      "en": "Locale-Aware Notifications",
+      "cs": "Notifikace reagující na změnu jazyka"
+    },
+    "features": {
+      "en": [
+        "Notifications re-render instantly when switching language",
+        "Structured notification templates (templateArgs) for locale-independent storage",
+        "Notification backup & restore support"
+      ],
+      "cs": [
+        "Notifikace se okamžitě přerenderují při přepnutí jazyka",
+        "Strukturované šablony notifikací (templateArgs) pro jazykově nezávislé ukládání",
+        "Podpora zálohování a obnovy notifikací"
+      ]
+    }
+  },
+  {
     "versionCode": 24100,
     "version": "2.4.1",
     "title": {


### PR DESCRIPTION
## Summary
- Notifications now re-render instantly when switching language (no app restart needed)
- Structured `templateArgs` (JSON) stored alongside notifications for locale-independent re-rendering
- `NotificationRenderer` renders title/message from templateArgs using current locale
- Room migration v2→v3 adds `templateArgs` column
- Backup/restore includes templateArgs field

## What's New
- **Instant locale switch**: `combine(daoFlow, localeTrigger)` + `createConfigurationContext()` ensures fresh locale-aware context on every language change
- **NotificationTemplateArgs**: Sealed class with `Purchase`, `PurchasePending`, `Error`, `LowBalance`, `WithdrawalThreshold`, `TargetReached`, `BelowMinimum` variants
- **NotificationRenderer**: Stateless object that renders any notification entity into localized title/message

## Test plan
- [ ] Enable sandbox mode, create test notifications
- [ ] Switch language CS ↔ EN — notifications update immediately
- [ ] Kill & reopen app — notifications still display correctly
- [ ] Backup → restore — templateArgs preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)