### PR TITLE
Market Pulse default OFF, auto-enable on ATH/F&G + filter quick amounts by min order

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/MainActivity.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/MainActivity.kt
@@ -96,11 +96,10 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (!isInstrumentedTest()) {
-            // Request necessary permissions
+        if (!isInstrumentedTest() && onboardingPreferences.isOnboardingCompleted()) {
+            // Request necessary permissions (only for returning users;
+            // new users get permissions via the onboarding Permissions screen)
             checkPermissions()
-
-            // Request battery optimization exemption for reliable background execution
             requestBatteryOptimizationExemption()
         }
 
@@ -300,7 +299,7 @@ fun AccBotApp(
                     navController.navigate(Screen.FirstPlan.route)
                 },
                 onSkip = {
-                    navController.navigate(Screen.OnboardingComplete.route)
+                    navController.navigate(Screen.Permissions.route)
                 },
                 onBack = { navController.popBackStack() }
             )
@@ -309,9 +308,18 @@ fun AccBotApp(
         composable(Screen.FirstPlan.route) {
             FirstPlanScreen(
                 onContinue = {
-                    navController.navigate(Screen.OnboardingComplete.route)
+                    navController.navigate(Screen.Permissions.route)
                 },
                 onSkip = {
+                    navController.navigate(Screen.Permissions.route)
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(Screen.Permissions.route) {
+            PermissionsScreen(
+                onContinue = {
                     navController.navigate(Screen.OnboardingComplete.route)
                 },
                 onBack = { navController.popBackStack() }

--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/UserPreferences.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/UserPreferences.kt
@@ -167,7 +167,7 @@ class UserPreferences @Inject constructor(
     // ==================== Market Pulse ====================
 
     fun isMarketPulseEnabled(): Boolean {
-        return prefs.getBoolean(KEY_MARKET_PULSE_ENABLED, true)
+        return prefs.getBoolean(KEY_MARKET_PULSE_ENABLED, false)
     }
 
     fun setMarketPulseEnabled(enabled: Boolean) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/navigation/Screen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/navigation/Screen.kt
@@ -10,6 +10,7 @@ sealed class Screen(val route: String) {
     data object Security : Screen("onboarding/security")
     data object ExchangeSetup : Screen("onboarding/exchange_setup")
     data object FirstPlan : Screen("onboarding/first_plan")
+    data object Permissions : Screen("onboarding/permissions")
     data object OnboardingComplete : Screen("onboarding/complete")
 
     // Main screens (with bottom nav)

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
@@ -221,7 +221,13 @@ fun AddPlanScreen(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    listOf("25", "50", "100", "250", "500").forEach { preset ->
+                    val quickAmounts = remember(uiState.minOrderSize) {
+                        val allAmounts = listOf("25", "50", "100", "250", "500")
+                        val min = uiState.minOrderSize
+                        if (min != null) allAmounts.filter { it.toBigDecimal() >= min }
+                        else allAmounts
+                    }
+                    quickAmounts.forEach { preset ->
                         OutlinedButton(
                             onClick = { viewModel.setAmount(preset) },
                             modifier = Modifier.weight(1f),

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanViewModel.kt
@@ -309,6 +309,11 @@ class AddPlanViewModel @Inject constructor(
 
                 dcaPlanDao.insertPlan(plan)
 
+                // Auto-enable Market Pulse when creating a plan with market-aware strategy
+                if (state.selectedStrategy is DcaStrategy.AthBased || state.selectedStrategy is DcaStrategy.FearAndGreed) {
+                    userPreferences.setMarketPulseEnabled(true)
+                }
+
                 val shouldOfferImport = !state.hasCredentials && exchange.supportsApiImport
                 _uiState.update { it.copy(
                     isLoading = false,

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
@@ -45,7 +45,7 @@ data class SettingsUiState(
     val isBiometricLockEnabled: Boolean = false,
     val withdrawalThresholds: List<WithdrawalThreshold> = emptyList(),
     val availableCryptoExchangePairs: List<Pair<String, Exchange>> = emptyList(),
-    val isMarketPulseEnabled: Boolean = true,
+    val isMarketPulseEnabled: Boolean = false,
     val appTheme: AppTheme = AppTheme.DARK,
     val dcaPlanCount: Int = 0,
     val transactionCount: Int = 0,

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/CompletionScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/CompletionScreen.kt
@@ -135,43 +135,6 @@ fun CompletionScreen(
                     title = stringResource(R.string.completion_fine_tune_title),
                     description = stringResource(R.string.completion_fine_tune_desc)
                 )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                NextStepItem(
-                    icon = Icons.Default.Notifications,
-                    title = stringResource(R.string.completion_stay_informed_title),
-                    description = stringResource(R.string.completion_stay_informed_desc)
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // Tips card
-        Card(
-            colors = CardDefaults.cardColors(
-                containerColor = accentColor().copy(alpha = 0.1f)
-            )
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.Top
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Lightbulb,
-                    contentDescription = null,
-                    tint = accentColor(),
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(
-                    text = stringResource(R.string.completion_pro_tip),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
             }
         }
 

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/FirstPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/FirstPlanScreen.kt
@@ -40,8 +40,13 @@ fun FirstPlanScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    // Quick amount presets
-    val quickAmounts = listOf("25", "50", "100", "250", "500")
+    // Quick amount presets — filter out values below minimum order size
+    val quickAmounts = remember(uiState.minOrderSize) {
+        val allAmounts = listOf("25", "50", "100", "250", "500")
+        val min = uiState.minOrderSize
+        if (min != null) allAmounts.filter { it.toBigDecimal() >= min }
+        else allAmounts
+    }
 
     // Simplified frequency options for onboarding
     val frequencyOptions = listOf(

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/PermissionsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/PermissionsScreen.kt
@@ -1,0 +1,328 @@
+package com.accbot.dca.presentation.screens.onboarding
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.accbot.dca.R
+import com.accbot.dca.presentation.ui.theme.accentColor
+import com.accbot.dca.presentation.ui.theme.successColor
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PermissionsScreen(
+    onContinue: () -> Unit,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Notification permission state (only relevant on API 33+)
+    var notificationGranted by remember {
+        mutableStateOf(
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+            } else {
+                true // Pre-33 doesn't need runtime permission
+            }
+        )
+    }
+
+    // Battery optimization state
+    var batteryUnrestricted by remember {
+        val pm = context.getSystemService(android.content.Context.POWER_SERVICE) as PowerManager
+        mutableStateOf(pm.isIgnoringBatteryOptimizations(context.packageName))
+    }
+
+    // Refresh states when returning from system dialogs
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    notificationGranted = ContextCompat.checkSelfPermission(
+                        context, Manifest.permission.POST_NOTIFICATIONS
+                    ) == PackageManager.PERMISSION_GRANTED
+                }
+                val pm = context.getSystemService(android.content.Context.POWER_SERVICE) as PowerManager
+                batteryUnrestricted = pm.isIgnoringBatteryOptimizations(context.packageName)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // Notification permission launcher
+    val notificationLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        notificationGranted = granted
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_back)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Progress indicator
+            LinearProgressIndicator(
+                progress = { 0.9f },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(4.dp)
+                    .clip(RoundedCornerShape(2.dp)),
+                color = accentColor()
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Shield icon
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(accentColor().copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Shield,
+                    contentDescription = null,
+                    tint = accentColor(),
+                    modifier = Modifier.size(40.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = stringResource(R.string.permissions_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = stringResource(R.string.permissions_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Notification permission card (only on API 33+)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                PermissionCard(
+                    icon = Icons.Default.Notifications,
+                    title = stringResource(R.string.permissions_notification_title),
+                    description = stringResource(R.string.permissions_notification_desc),
+                    granted = notificationGranted,
+                    grantedLabel = stringResource(R.string.permissions_notification_granted),
+                    buttonLabel = stringResource(R.string.permissions_notification_enable),
+                    onRequest = {
+                        notificationLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // Battery optimization card
+            PermissionCard(
+                icon = Icons.Default.BatteryChargingFull,
+                title = stringResource(R.string.permissions_battery_title),
+                description = stringResource(R.string.permissions_battery_desc),
+                granted = batteryUnrestricted,
+                grantedLabel = stringResource(R.string.permissions_battery_granted),
+                buttonLabel = stringResource(R.string.permissions_battery_enable),
+                onRequest = {
+                    try {
+                        val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                            data = Uri.parse("package:${context.packageName}")
+                        }
+                        context.startActivity(intent)
+                    } catch (_: Exception) {
+                        try {
+                            context.startActivity(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+                        } catch (_: Exception) {
+                            // Device doesn't support battery optimization settings
+                        }
+                    }
+                }
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Info tip card
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = accentColor().copy(alpha = 0.1f)
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = null,
+                        tint = accentColor(),
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = stringResource(R.string.permissions_tip),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Continue button — always enabled
+            Button(
+                onClick = onContinue,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = accentColor()
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.permissions_continue),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun PermissionCard(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    granted: Boolean,
+    grantedLabel: String,
+    buttonLabel: String,
+    onRequest: () -> Unit
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = if (granted) successColor() else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = title,
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedButton(
+                onClick = onRequest,
+                enabled = !granted,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = if (granted) successColor() else accentColor()
+                )
+            ) {
+                Icon(
+                    imageVector = if (granted) Icons.Default.CheckCircle else icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = if (granted) grantedLabel else buttonLabel,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -512,9 +512,19 @@
     <string name="completion_start_service_desc">Zapněte službu z přehledu</string>
     <string name="completion_fine_tune_title">Doladit plán</string>
     <string name="completion_fine_tune_desc">Upravte částky, přidejte další kryptoměny nebo změňte frekvenci</string>
-    <string name="completion_stay_informed_title">Buďte informováni</string>
-    <string name="completion_stay_informed_desc">Dostávejte upozornění po každém nákupu</string>
-    <string name="completion_pro_tip">Pro tip: Pro nepřerušované DCA vypněte optimalizaci baterie pro AccBot v nastavení zařízení.</string>
+    <!-- Permissions onboarding -->
+    <string name="permissions_title">Povolte spolehlivé nákupy</string>
+    <string name="permissions_subtitle">AccBot potřebuje tato oprávnění, aby mohl spolehlivě nakupovat na pozadí</string>
+    <string name="permissions_notification_title">Oznámení</string>
+    <string name="permissions_notification_desc">Dostávejte upozornění na dokončené nákupy, chyby a nízký zůstatek</string>
+    <string name="permissions_notification_enable">Povolit oznámení</string>
+    <string name="permissions_notification_granted">Oznámení povolena</string>
+    <string name="permissions_battery_title">Neomezené běžení na pozadí</string>
+    <string name="permissions_battery_desc">Povolte AccBotu spolehlivě běžet na pozadí, aby se vaše DCA vykonávalo podle plánu</string>
+    <string name="permissions_battery_enable">Zrušit omezení</string>
+    <string name="permissions_battery_granted">Neomezeno</string>
+    <string name="permissions_tip">Tato nastavení můžete kdykoli změnit v Nastavení.</string>
+    <string name="permissions_continue">Pokračovat</string>
     <string name="completion_start_stacking">Začít nakupovat</string>
 
     <!-- Notifications -->

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -511,9 +511,19 @@
     <string name="completion_start_service_desc">Toggle the service on from the dashboard</string>
     <string name="completion_fine_tune_title">Fine-tune your plan</string>
     <string name="completion_fine_tune_desc">Adjust amounts, add more cryptos, or change frequency</string>
-    <string name="completion_stay_informed_title">Stay informed</string>
-    <string name="completion_stay_informed_desc">Get notified after each purchase</string>
-    <string name="completion_pro_tip">Pro tip: For uninterrupted DCA, disable battery optimization for AccBot in your device settings.</string>
+    <!-- Permissions onboarding -->
+    <string name="permissions_title">Enable Reliable Purchases</string>
+    <string name="permissions_subtitle">AccBot needs these permissions to reliably execute purchases in the background</string>
+    <string name="permissions_notification_title">Notifications</string>
+    <string name="permissions_notification_desc">Get alerted on completed purchases, errors, and low balance warnings</string>
+    <string name="permissions_notification_enable">Enable Notifications</string>
+    <string name="permissions_notification_granted">Notifications Enabled</string>
+    <string name="permissions_battery_title">Unrestricted Background</string>
+    <string name="permissions_battery_desc">Allow AccBot to run reliably in the background so your DCA executes on schedule</string>
+    <string name="permissions_battery_enable">Disable Restrictions</string>
+    <string name="permissions_battery_granted">Unrestricted</string>
+    <string name="permissions_tip">You can change these settings anytime from the Settings screen.</string>
+    <string name="permissions_continue">Continue</string>
     <string name="completion_start_stacking">Start Stacking</string>
 
     <!-- Notifications -->


### PR DESCRIPTION
## Summary
- **Market Pulse defaults to OFF** — no longer shows empty/useless data for new users without ATH or F&G plans
- **Auto-enables Market Pulse** when user creates an ATH-based or Fear & Greed DCA plan
- **Filters quick amount presets** against exchange minimum order size (e.g. Coinmate CZK min 50 → hides "25" button)
- **Onboarding Permissions screen** — notifications and battery optimization are now requested in a dedicated step instead of on app launch

## Test plan
- [ ] Fresh install → Market Pulse section hidden on Dashboard (default OFF)
- [ ] Create ATH-based or F&G plan → Market Pulse auto-enables, visible on Dashboard
- [ ] Settings toggle → user can still manually enable/disable anytime
- [ ] Coinmate + CZK → quick amounts show 50, 100, 250, 500 (no 25)
- [ ] Coinmate + EUR → quick amounts show 25, 50, 100, 250, 500 (all shown)
- [ ] New user onboarding → Permissions screen appears before Completion screen
- [ ] Returning users → permissions still checked in MainActivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)