### PR TITLE
Add experimental exchanges toggle and request exchange

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/data/local/UserPreferences.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/data/local/UserPreferences.kt
@@ -182,6 +182,16 @@ class UserPreferences @Inject constructor(
         prefs.edit().putBoolean(KEY_MARKET_PULSE_EXPANDED, expanded).apply()
     }
 
+    // ==================== Experimental Exchanges ====================
+
+    fun areExperimentalExchangesEnabled(): Boolean {
+        return prefs.getBoolean(KEY_EXPERIMENTAL_EXCHANGES, false)
+    }
+
+    fun setExperimentalExchangesEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_EXPERIMENTAL_EXCHANGES, enabled).apply()
+    }
+
     // ==================== Sandbox Mode ====================
 
     /**
@@ -215,5 +225,6 @@ class UserPreferences @Inject constructor(
         private const val KEY_LAST_SEEN_VERSION_CODE = "last_seen_version_code"
         private const val KEY_MARKET_PULSE_ENABLED = "market_pulse_enabled"
         private const val KEY_MARKET_PULSE_EXPANDED = "market_pulse_expanded"
+        private const val KEY_EXPERIMENTAL_EXCHANGES = "experimental_exchanges_enabled"
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/domain/model/Models.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/domain/model/Models.kt
@@ -96,6 +96,11 @@ fun Exchange.supportsSandbox(): Boolean = sandboxSupport == SandboxSupport.FULL
 val Exchange.supportsApiImport: Boolean get() = this in setOf(Exchange.COINMATE, Exchange.BINANCE, Exchange.KRAKEN, Exchange.COINBASE)
 
 /**
+ * Whether this exchange has been fully tested and is considered stable.
+ */
+val Exchange.isStable: Boolean get() = this in setOf(Exchange.COINMATE, Exchange.BINANCE)
+
+/**
  * Get list of available exchanges based on sandbox mode.
  * In sandbox mode, only exchanges with full sandbox support are returned.
  * This is a cached list to avoid recreating on each call.

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
@@ -1,5 +1,7 @@
 package com.accbot.dca.presentation.screens
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -16,7 +18,10 @@ import androidx.compose.runtime.*
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -31,6 +36,9 @@ import com.accbot.dca.R
 import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.DcaStrategy
 import com.accbot.dca.domain.model.Exchange
+import com.accbot.dca.domain.model.isStable
+import com.accbot.dca.presentation.ui.theme.Warning
+import com.accbot.dca.presentation.components.ExchangeAvatar
 import com.accbot.dca.presentation.components.CredentialsInputCard
 import com.accbot.dca.presentation.components.MonthlyCostEstimateCard
 import com.accbot.dca.presentation.components.QrScannerButton
@@ -88,7 +96,7 @@ fun AddPlanScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.add_plan_title)) },
+                title = { Text(stringResource(R.string.add_plan_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.common_back))
@@ -124,28 +132,108 @@ fun AddPlanScreen(
                 SandboxModeIndicator()
             }
 
+            // Experimental exchange disclaimer (selecting an experimental exchange)
+            var experimentalExchangePending by remember { mutableStateOf<Exchange?>(null) }
+            experimentalExchangePending?.let { exchange ->
+                AlertDialog(
+                    onDismissRequest = { experimentalExchangePending = null },
+                    title = { Text(stringResource(R.string.experimental_exchange_warning_title)) },
+                    text = { Text(stringResource(R.string.experimental_exchange_warning_text)) },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            experimentalExchangePending = null
+                            viewModel.selectExchange(exchange)
+                        }) {
+                            Text(stringResource(R.string.experimental_warning_confirm))
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { experimentalExchangePending = null }) {
+                            Text(stringResource(R.string.common_back))
+                        }
+                    }
+                )
+            }
+
+            // Experimental toggle disclaimer (enabling the toggle)
+            var showExperimentalDisclaimer by remember { mutableStateOf(false) }
+            if (showExperimentalDisclaimer) {
+                AlertDialog(
+                    onDismissRequest = { showExperimentalDisclaimer = false },
+                    title = { Text(stringResource(R.string.experimental_warning_title)) },
+                    text = { Text(stringResource(R.string.experimental_warning_text)) },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            showExperimentalDisclaimer = false
+                            viewModel.setExperimentalExchangesEnabled(true)
+                        }) {
+                            Text(stringResource(R.string.experimental_warning_confirm))
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showExperimentalDisclaimer = false }) {
+                            Text(stringResource(R.string.common_back))
+                        }
+                    }
+                )
+            }
+
+            val addPlanContext = LocalContext.current
+
             Column(
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                uiState.availableExchanges.chunked(3).forEach { row ->
+                // Build items: exchanges + request card tile
+                data class ExchangeItem(val exchange: Exchange?, val isRequestCard: Boolean = false)
+                val items = uiState.availableExchanges.map { ExchangeItem(it) } + ExchangeItem(null, isRequestCard = true)
+
+                items.chunked(2).forEach { row ->
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        row.forEach { exchange ->
-                            ExchangeCard(
-                                exchange = exchange,
-                                isSelected = uiState.selectedExchange == exchange,
-                                onClick = { viewModel.selectExchange(exchange) },
-                                modifier = Modifier.weight(1f)
-                            )
+                        row.forEach { item ->
+                            if (item.isRequestCard) {
+                                RequestExchangeTile(
+                                    onClick = {
+                                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/Crynners/AccBot/issues"))
+                                        addPlanContext.startActivity(intent)
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                )
+                            } else {
+                                ExchangeCard(
+                                    exchange = item.exchange!!,
+                                    isSelected = uiState.selectedExchange == item.exchange,
+                                    onClick = {
+                                        if (item.exchange.isStable) {
+                                            viewModel.selectExchange(item.exchange)
+                                        } else {
+                                            experimentalExchangePending = item.exchange
+                                        }
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
                         }
-                        // Fill remaining slots for incomplete rows
-                        repeat(3 - row.size) {
+                        // Fill remaining slot for incomplete row
+                        repeat(2 - row.size) {
                             Spacer(modifier = Modifier.weight(1f))
                         }
                     }
                 }
+
+                // Experimental exchanges toggle
+                ExperimentalToggleRow(
+                    isEnabled = uiState.showExperimental,
+                    onToggle = { enabled ->
+                        if (enabled) {
+                            showExperimentalDisclaimer = true
+                        } else {
+                            viewModel.setExperimentalExchangesEnabled(false)
+                        }
+                    }
+                )
             }
 
             // API Credentials
@@ -437,21 +525,131 @@ private fun ExchangeCard(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
+                .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Image(
-                painter = painterResource(exchange.logoRes),
-                contentDescription = exchange.displayName,
-                modifier = Modifier.size(28.dp),
-                contentScale = ContentScale.Fit
+            ExchangeAvatar(
+                exchange = exchange,
+                size = 48.dp,
+                isConnected = isSelected
             )
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = exchange.displayName,
+                style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
-                style = MaterialTheme.typography.bodySmall,
                 color = if (isSelected) successCol else MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.add_exchange_cryptos, exchange.supportedCryptos.size),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (!exchange.isStable) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.experimental_badge),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Warning,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RequestExchangeTile(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedCard(
+        modifier = modifier
+            .clickable(onClick = onClick),
+        border = CardDefaults.outlinedCardBorder()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.add_exchange_request),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExperimentalToggleRow(
+    isEnabled: Boolean,
+    onToggle: (Boolean) -> Unit
+) {
+    val haptic = LocalHapticFeedback.current
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                onToggle(!isEnabled)
+            }
+            .semantics(mergeDescendants = true) { role = Role.Switch },
+        colors = CardDefaults.cardColors(
+            containerColor = if (isEnabled) Warning.copy(alpha = 0.1f) else MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Explore,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_experimental_exchanges),
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = if (isEnabled) {
+                        stringResource(R.string.settings_experimental_exchanges_enabled)
+                    } else {
+                        stringResource(R.string.settings_experimental_exchanges_disabled)
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = isEnabled,
+                onCheckedChange = null,
+                modifier = Modifier
+                    .clearAndSetSemantics {}
+                    .height(24.dp),
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Warning,
+                    checkedTrackColor = Warning.copy(alpha = 0.5f)
+                )
             )
         }
     }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanViewModel.kt
@@ -14,6 +14,7 @@ import com.accbot.dca.domain.util.CronUtils
 import com.accbot.dca.presentation.model.MonthlyCostEstimate
 import com.accbot.dca.domain.model.ExchangeFilter
 import com.accbot.dca.domain.model.ExchangeInstructions
+import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.domain.model.ExchangeInstructionsProvider
 import com.accbot.dca.domain.usecase.CalculateMonthlyCostUseCase
 import com.accbot.dca.domain.usecase.CredentialValidationResult
@@ -35,6 +36,7 @@ data class AddPlanUiState(
     // Sandbox state (immutable after init)
     val isSandboxMode: Boolean = false,
     val availableExchanges: List<Exchange> = emptyList(),
+    val showExperimental: Boolean = false,
 
     // Exchange setup
     val selectedExchange: Exchange? = null,
@@ -105,10 +107,24 @@ class AddPlanViewModel @Inject constructor(
 
     init {
         // Initialize sandbox state once - avoids repeated calls during recomposition
+        val showExperimental = userPreferences.areExperimentalExchangesEnabled()
         _uiState.update {
             it.copy(
                 isSandboxMode = isSandbox,
+                showExperimental = showExperimental,
                 availableExchanges = ExchangeFilter.getAvailableExchanges(isSandbox)
+                    .filter { exchange -> showExperimental || exchange.isStable }
+            )
+        }
+    }
+
+    fun setExperimentalExchangesEnabled(enabled: Boolean) {
+        userPreferences.setExperimentalExchangesEnabled(enabled)
+        _uiState.update {
+            it.copy(
+                showExperimental = enabled,
+                availableExchanges = ExchangeFilter.getAvailableExchanges(isSandbox)
+                    .filter { exchange -> enabled || exchange.isStable }
             )
         }
     }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsScreen.kt
@@ -1143,3 +1143,4 @@ internal fun SandboxToggleCard(
         }
     )
 }
+

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/SettingsViewModel.kt
@@ -53,7 +53,8 @@ data class SettingsUiState(
     val notificationsEnabled: Boolean = true,
     val purchaseNotificationsEnabled: Boolean = true,
     val errorNotificationsEnabled: Boolean = true,
-    val weeklySummaryEnabled: Boolean = false
+    val weeklySummaryEnabled: Boolean = false,
+    val isExperimentalExchangesEnabled: Boolean = false
 )
 
 @HiltViewModel
@@ -104,7 +105,8 @@ class SettingsViewModel @Inject constructor(
                 languageTag = userPreferences.getLanguageTag(),
                 appTheme = userPreferences.getAppTheme(),
                 isBiometricLockEnabled = userPreferences.isBiometricLockEnabled(),
-                isMarketPulseEnabled = userPreferences.isMarketPulseEnabled()
+                isMarketPulseEnabled = userPreferences.isMarketPulseEnabled(),
+                isExperimentalExchangesEnabled = userPreferences.areExperimentalExchangesEnabled()
             )
         }
     }
@@ -157,6 +159,11 @@ class SettingsViewModel @Inject constructor(
     @Deprecated("Use requestSandboxModeChange() instead - requires app restart")
     fun toggleSandboxMode() {
         requestSandboxModeChange()
+    }
+
+    fun setExperimentalExchangesEnabled(enabled: Boolean) {
+        userPreferences.setExperimentalExchangesEnabled(enabled)
+        _uiState.update { it.copy(isExperimentalExchangesEnabled = enabled) }
     }
 
     fun setMarketPulseEnabled(enabled: Boolean) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
@@ -33,6 +33,7 @@ import com.accbot.dca.R
 import com.accbot.dca.data.local.DcaPlanEntity
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.ExchangeInstructions
+import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.domain.model.supportsApiImport
 import com.accbot.dca.domain.usecase.ApiImportResultState
 import com.accbot.dca.presentation.components.AccBotTopAppBar
@@ -158,6 +159,31 @@ private fun ExchangeSelectionStep(
     onSelectExchange: (Exchange) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+    var experimentalExchangePending by remember { mutableStateOf<Exchange?>(null) }
+
+    // Experimental exchange disclaimer dialog
+    experimentalExchangePending?.let { exchange ->
+        AlertDialog(
+            onDismissRequest = { experimentalExchangePending = null },
+            title = { Text(stringResource(R.string.experimental_exchange_warning_title)) },
+            text = { Text(stringResource(R.string.experimental_exchange_warning_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    experimentalExchangePending = null
+                    onSelectExchange(exchange)
+                }) {
+                    Text(stringResource(R.string.experimental_warning_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { experimentalExchangePending = null }) {
+                    Text(stringResource(R.string.common_back))
+                }
+            }
+        )
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -179,7 +205,23 @@ private fun ExchangeSelectionStep(
             items(availableExchanges, key = { it.name }) { exchange ->
                 ExchangeSelectionCard(
                     exchange = exchange,
-                    onClick = { onSelectExchange(exchange) }
+                    onClick = {
+                        if (exchange.isStable) {
+                            onSelectExchange(exchange)
+                        } else {
+                            experimentalExchangePending = exchange
+                        }
+                    }
+                )
+            }
+
+            // "Request Exchange" card
+            item {
+                RequestExchangeCard(
+                    onClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/Crynners/AccBot/issues"))
+                        context.startActivity(intent)
+                    }
                 )
             }
         }
@@ -250,6 +292,50 @@ internal fun ExchangeSelectionCard(
             Text(
                 text = stringResource(R.string.add_exchange_cryptos, exchange.supportedCryptos.size),
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            if (!exchange.isStable) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.experimental_badge),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Warning,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RequestExchangeCard(
+    onClick: () -> Unit
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        border = CardDefaults.outlinedCardBorder()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.add_exchange_request),
+                fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeViewModel.kt
@@ -14,6 +14,7 @@ import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.ExchangeInstructions
 import com.accbot.dca.domain.model.ExchangeInstructionsProvider
+import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.domain.model.supportsApiImport
 import com.accbot.dca.domain.model.supportsSandbox
 import com.accbot.dca.domain.usecase.ApiImportProgress
@@ -284,9 +285,11 @@ class AddExchangeViewModel @Inject constructor(
 
     fun getAvailableExchanges(): List<Exchange> {
         val isSandbox = userPreferences.isSandboxMode()
+        val showExperimental = userPreferences.areExperimentalExchangesEnabled()
         return Exchange.entries
             .filter { !credentialsStore.hasCredentials(it, isSandbox) }
             .filter { !isSandbox || it.supportsSandbox() }
+            .filter { showExperimental || it.isStable }
     }
 
     fun getInstructionsForExchange(exchange: Exchange): ExchangeInstructions {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
@@ -1,5 +1,7 @@
 package com.accbot.dca.presentation.screens.exchanges
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -16,17 +18,26 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
 import com.accbot.dca.domain.model.Exchange
+import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.presentation.components.AccBotTopAppBar
 import com.accbot.dca.presentation.components.EmptyState
 import com.accbot.dca.presentation.components.ExchangeAvatar
 import com.accbot.dca.presentation.components.SectionHeader
+import com.accbot.dca.presentation.ui.theme.Warning
 import com.accbot.dca.presentation.ui.theme.successColor
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -38,6 +49,28 @@ fun ExchangeManagementScreen(
     viewModel: ExchangeManagementViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showExperimentalDisclaimer by remember { mutableStateOf(false) }
+
+    if (showExperimentalDisclaimer) {
+        AlertDialog(
+            onDismissRequest = { showExperimentalDisclaimer = false },
+            title = { Text(stringResource(R.string.experimental_warning_title)) },
+            text = { Text(stringResource(R.string.experimental_warning_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showExperimentalDisclaimer = false
+                    viewModel.setExperimentalExchangesEnabled(true)
+                }) {
+                    Text(stringResource(R.string.experimental_warning_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showExperimentalDisclaimer = false }) {
+                    Text(stringResource(R.string.common_back))
+                }
+            }
+        )
+    }
 
     // Refresh when returning to screen (e.g. after removing exchange in detail)
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -59,7 +92,9 @@ fun ExchangeManagementScreen(
             )
         }
     ) { paddingValues ->
-        val availableExchanges = Exchange.entries.filter { it !in uiState.connectedExchanges }
+        val availableExchanges = Exchange.entries
+            .filter { it !in uiState.connectedExchanges }
+            .filter { uiState.showExperimental || it.isStable }
 
         if (uiState.connectedExchanges.isEmpty() && availableExchanges.isEmpty()) {
             Box(
@@ -105,11 +140,11 @@ fun ExchangeManagementScreen(
                 }
 
                 // Available exchanges section
-                if (availableExchanges.isNotEmpty()) {
-                    item(span = { GridItemSpan(maxLineSpan) }) {
-                        SectionHeader(title = stringResource(R.string.exchanges_available))
-                    }
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    SectionHeader(title = stringResource(R.string.exchanges_available))
+                }
 
+                if (availableExchanges.isNotEmpty()) {
                     items(availableExchanges, key = { it.name }) { exchange ->
                         ExchangeTile(
                             exchange = exchange,
@@ -117,6 +152,31 @@ fun ExchangeManagementScreen(
                             onClick = { onNavigateToAddExchange(exchange.name) }
                         )
                     }
+                }
+
+                // Request Exchange card
+                item {
+                    val context = LocalContext.current
+                    RequestExchangeTile(
+                        onClick = {
+                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/Crynners/AccBot/issues"))
+                            context.startActivity(intent)
+                        }
+                    )
+                }
+
+                // Experimental exchanges toggle
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    ExperimentalExchangesToggle(
+                        isEnabled = uiState.showExperimental,
+                        onToggle = { enabled ->
+                            if (enabled) {
+                                showExperimentalDisclaimer = true
+                            } else {
+                                viewModel.setExperimentalExchangesEnabled(false)
+                            }
+                        }
+                    )
                 }
 
                 item(span = { GridItemSpan(maxLineSpan) }) {
@@ -171,6 +231,110 @@ private fun ExchangeTile(
                 style = MaterialTheme.typography.bodySmall,
                 color = if (isConnected) successCol else MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
+            )
+            if (!isConnected && !exchange.isStable) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.experimental_badge),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Warning,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RequestExchangeTile(
+    onClick: () -> Unit
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        border = CardDefaults.outlinedCardBorder()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.add_exchange_request),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExperimentalExchangesToggle(
+    isEnabled: Boolean,
+    onToggle: (Boolean) -> Unit
+) {
+    val haptic = LocalHapticFeedback.current
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp)
+            .clickable {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                onToggle(!isEnabled)
+            }
+            .semantics(mergeDescendants = true) { role = Role.Switch },
+        colors = CardDefaults.cardColors(
+            containerColor = if (isEnabled) Warning.copy(alpha = 0.1f) else MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Explore,
+                contentDescription = null,
+                tint = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_experimental_exchanges),
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = if (isEnabled) {
+                        stringResource(R.string.settings_experimental_exchanges_enabled)
+                    } else {
+                        stringResource(R.string.settings_experimental_exchanges_disabled)
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = isEnabled,
+                onCheckedChange = null,
+                modifier = Modifier.clearAndSetSemantics {},
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Warning,
+                    checkedTrackColor = Warning.copy(alpha = 0.5f)
+                )
             )
         }
     }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.accbot.dca.data.local.CredentialsStore
 import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.domain.model.Exchange
+import com.accbot.dca.domain.model.isStable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
@@ -17,7 +18,8 @@ import javax.inject.Inject
 data class ExchangeManagementUiState(
     val connectedExchanges: List<Exchange> = emptyList(),
     val isLoading: Boolean = false,
-    val isSandboxMode: Boolean = false
+    val isSandboxMode: Boolean = false,
+    val showExperimental: Boolean = false
 )
 
 @HiltViewModel
@@ -37,8 +39,14 @@ class ExchangeManagementViewModel @Inject constructor(
         viewModelScope.launch {
             val isSandbox = withContext(Dispatchers.IO) { userPreferences.isSandboxMode() }
             val connected = withContext(Dispatchers.IO) { credentialsStore.getConfiguredExchanges(isSandbox) }
-            _uiState.update { it.copy(connectedExchanges = connected, isSandboxMode = isSandbox) }
+            val showExperimental = withContext(Dispatchers.IO) { userPreferences.areExperimentalExchangesEnabled() }
+            _uiState.update { it.copy(connectedExchanges = connected, isSandboxMode = isSandbox, showExperimental = showExperimental) }
         }
+    }
+
+    fun setExperimentalExchangesEnabled(enabled: Boolean) {
+        userPreferences.setExperimentalExchangesEnabled(enabled)
+        _uiState.update { it.copy(showExperimental = enabled) }
     }
 
     fun removeExchange(exchange: Exchange) {

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
@@ -42,7 +42,7 @@ fun ExchangeSetupScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.exchange_setup_title)) },
+                title = { Text(stringResource(R.string.exchange_setup_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.common_back))

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/FirstPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/FirstPlanScreen.kt
@@ -57,7 +57,7 @@ fun FirstPlanScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.first_plan_title)) },
+                title = { Text(stringResource(R.string.first_plan_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.common_back))

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -833,6 +833,18 @@
     <string name="settings_market_pulse_title">Tržní nálada</string>
     <string name="settings_market_pulse_subtitle">Zobrazit tržní indikátory na přehledu</string>
 
+    <!-- Experimental Exchanges -->
+    <string name="settings_experimental_exchanges">Experimentální burzy</string>
+    <string name="settings_experimental_exchanges_enabled">Zobrazují se netestované burzy</string>
+    <string name="settings_experimental_exchanges_disabled">Zobrazují se pouze stabilní burzy</string>
+    <string name="experimental_badge">Experimentální</string>
+    <string name="experimental_warning_title">Experimentální burzy</string>
+    <string name="experimental_warning_text">Tyto burzy nebyly plně otestovány. Mohou se vyskytnout chyby. Prosím nahlaste problémy.</string>
+    <string name="experimental_exchange_warning_title">Experimentální burza</string>
+    <string name="experimental_exchange_warning_text">Tato burza nebyla plně otestována. Mohou se vyskytnout chyby. Prosím nahlaste problémy.</string>
+    <string name="experimental_warning_confirm">Rozumím</string>
+    <string name="add_exchange_request">Požádat o burzu</string>
+
     <!-- Accessibility -->
     <string name="a11y_retry">Opakovat</string>
 </resources>

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -828,6 +828,18 @@
     <string name="settings_market_pulse_title">Market Pulse</string>
     <string name="settings_market_pulse_subtitle">Show market indicators on dashboard</string>
 
+    <!-- Experimental Exchanges -->
+    <string name="settings_experimental_exchanges">Experimental Exchanges</string>
+    <string name="settings_experimental_exchanges_enabled">Showing untested exchanges</string>
+    <string name="settings_experimental_exchanges_disabled">Only stable exchanges are shown</string>
+    <string name="experimental_badge">Experimental</string>
+    <string name="experimental_warning_title">Experimental Exchanges</string>
+    <string name="experimental_warning_text">These exchanges have not been fully tested. Bugs may occur. Please report any issues.</string>
+    <string name="experimental_exchange_warning_title">Experimental Exchange</string>
+    <string name="experimental_exchange_warning_text">This exchange has not been fully tested. Bugs may occur. Please report any issues.</string>
+    <string name="experimental_warning_confirm">I Understand</string>
+    <string name="add_exchange_request">Request Exchange</string>
+
     <!-- Accessibility -->
     <string name="a11y_retry">Retry</string>
 </resources>


### PR DESCRIPTION
## Summary
- Hide untested exchanges (Kraken, KuCoin, Bitfinex, Huobi, Coinbase) behind an opt-in "Experimental Exchanges" toggle with disclaimer dialog
- Only stable exchanges (Coinmate, Binance) shown by default
- Add "Request Exchange" tile that opens GitHub Issues for users to request new exchanges
- Applied consistently across Exchange Management, Add Exchange, and Create DCA Plan screens
- Includes EN/CS localization for all new strings

## Test plan
- [ ] Verify only Coinmate + Binance + "Request Exchange" tile shown by default on all exchange selection surfaces
- [ ] Enable experimental toggle → verify disclaimer dialog appears → confirm shows all 7 exchanges with "Experimental" badge
- [ ] Select an experimental exchange → verify individual disclaimer dialog appears
- [ ] Tap "Request Exchange" → verify opens GitHub issues in browser
- [ ] Disable toggle → verify experimental exchanges hidden again
- [ ] Verify toggle state persists across screens and app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)