### PR TITLE
Add Market Pulse info bottom sheet

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/MarketPulseInfoSheet.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/MarketPulseInfoSheet.kt
@@ -1,0 +1,218 @@
+package com.accbot.dca.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.TrendingDown
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.accbot.dca.R
+import com.accbot.dca.presentation.ui.theme.accentColor
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarketPulseInfoSheet(onDismiss: () -> Unit) {
+    val accentCol = accentColor()
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            // Header with icon
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(accentCol.copy(alpha = 0.15f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.BarChart,
+                        contentDescription = null,
+                        tint = accentCol,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                Column {
+                    Text(
+                        text = stringResource(R.string.market_pulse_info_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = stringResource(R.string.market_pulse_info_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // Overview
+            Text(
+                text = stringResource(R.string.market_pulse_info_overview),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Fear & Greed section
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Psychology,
+                    contentDescription = null,
+                    tint = accentCol,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.market_pulse_info_fg_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.market_pulse_info_fg_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Color-coded scale card
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                )
+            ) {
+                Column(modifier = Modifier.padding(12.dp)) {
+                    FearGreedScaleRow(Color(0xFFE53935), stringResource(R.string.market_pulse_info_fg_extreme_fear), stringResource(R.string.market_pulse_info_fg_extreme_fear_desc))
+                    FearGreedScaleRow(Color(0xFFFF9800), stringResource(R.string.market_pulse_info_fg_fear), stringResource(R.string.market_pulse_info_fg_fear_desc))
+                    FearGreedScaleRow(Color(0xFFFDD835), stringResource(R.string.market_pulse_info_fg_neutral), stringResource(R.string.market_pulse_info_fg_neutral_desc))
+                    FearGreedScaleRow(Color(0xFF8BC34A), stringResource(R.string.market_pulse_info_fg_greed), stringResource(R.string.market_pulse_info_fg_greed_desc))
+                    FearGreedScaleRow(Color(0xFF4CAF50), stringResource(R.string.market_pulse_info_fg_extreme_greed), stringResource(R.string.market_pulse_info_fg_extreme_greed_desc))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ATH Distance section
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.TrendingDown,
+                    contentDescription = null,
+                    tint = accentCol,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.market_pulse_info_ath_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.market_pulse_info_ath_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // DCA tip card
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = accentCol.copy(alpha = 0.1f)
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Lightbulb,
+                        contentDescription = null,
+                        tint = accentCol,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.market_pulse_info_dca_tip),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Close button
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = accentCol)
+            ) {
+                Text(stringResource(R.string.strategy_got_it))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FearGreedScaleRow(color: Color, label: String, description: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/DashboardScreen.kt
@@ -63,6 +63,7 @@ import com.accbot.dca.domain.model.DcaStrategy
 import com.accbot.dca.domain.util.CronUtils
 import com.accbot.dca.presentation.components.CryptoIcon
 import com.accbot.dca.presentation.components.EmptyState
+import com.accbot.dca.presentation.components.MarketPulseInfoSheet
 import com.accbot.dca.presentation.components.SectionHeader
 import com.accbot.dca.presentation.ui.theme.Error
 import com.accbot.dca.presentation.ui.theme.Warning
@@ -1217,9 +1218,14 @@ internal fun MarketPulseCard(
     onToggleExpand: () -> Unit = {}
 ) {
     val indicatorColor = MaterialTheme.colorScheme.onSurface
+    var showMarketPulseInfo by remember { mutableStateOf(false) }
 
     // Localized F&G classification
     val localizedClassification = fearGreedData?.let { localizedFearGreedClass(it.value) }
+
+    if (showMarketPulseInfo) {
+        MarketPulseInfoSheet(onDismiss = { showMarketPulseInfo = false })
+    }
 
     Card(
         modifier = Modifier
@@ -1243,8 +1249,21 @@ internal fun MarketPulseCard(
                 Text(
                     text = stringResource(R.string.dashboard_market_pulse),
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f)
                 )
+                IconButton(
+                    onClick = { showMarketPulseInfo = true },
+                    modifier = Modifier.size(24.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = stringResource(R.string.market_pulse_info_title),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
                 Icon(
                     imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
                     contentDescription = if (isExpanded) stringResource(R.string.common_collapse) else stringResource(R.string.common_expand),

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -829,6 +829,26 @@
     <string name="fg_class_extreme_greed">Extrémní chamtivost</string>
     <string name="dashboard_purchase_amount_formula">%1$s %2$s (%3$s × %4$s) • %5$s</string>
 
+    <!-- Market Pulse Info Sheet -->
+    <string name="market_pulse_info_title">Tržní nálada</string>
+    <string name="market_pulse_info_subtitle">Vysvětlení tržních indikátorů</string>
+    <string name="market_pulse_info_overview">Tržní nálada zobrazuje dva klíčové indikátory, které vám pomohou rychle pochopit aktuální stav kryptoměnového trhu.</string>
+    <string name="market_pulse_info_fg_title">Index strachu a chamtivosti</string>
+    <string name="market_pulse_info_fg_description">Index strachu a chamtivosti měří celkovou náladu kryptotrhu na stupnici od 0 (extrémní strach) do 100 (extrémní chamtivost). Kombinuje signály jako volatilita, objem, sociální média a trendy.</string>
+    <string name="market_pulse_info_fg_extreme_fear">Extrémní strach (0–19)</string>
+    <string name="market_pulse_info_fg_extreme_fear_desc">Investoři mají velký strach — často příležitost k nákupu</string>
+    <string name="market_pulse_info_fg_fear">Strach (20–39)</string>
+    <string name="market_pulse_info_fg_fear_desc">Trh je opatrný — ceny mohou být podhodnocené</string>
+    <string name="market_pulse_info_fg_neutral">Neutrální (40–59)</string>
+    <string name="market_pulse_info_fg_neutral_desc">Vyvážená nálada — žádný silný signál</string>
+    <string name="market_pulse_info_fg_greed">Chamtivost (60–79)</string>
+    <string name="market_pulse_info_fg_greed_desc">Optimismus je vysoký — ceny mohou být nadsazené</string>
+    <string name="market_pulse_info_fg_extreme_greed">Extrémní chamtivost (80–100)</string>
+    <string name="market_pulse_info_fg_extreme_greed_desc">Euforie — trh může být přehřátý</string>
+    <string name="market_pulse_info_ath_title">Vzdálenost od ATH</string>
+    <string name="market_pulse_info_ath_description">Vzdálenost od ATH ukazuje, jak daleko je aktuální cena od svého historického maxima. Vzdálenost 0 % znamená, že cena je na ATH; 50 % znamená, že cena klesla na polovinu z maxima.</string>
+    <string name="market_pulse_info_dca_tip">Strategie DCA dle strachu a chamtivosti a dle ATH používají tyto indikátory k automatické úpravě nákupních částek — nakupují více, když je trh ve strachu nebo daleko od ATH, a méně, když je chamtivý nebo blízko vrcholu.</string>
+
     <!-- Settings: Market Pulse -->
     <string name="settings_market_pulse_title">Tržní nálada</string>
     <string name="settings_market_pulse_subtitle">Zobrazit tržní indikátory na přehledu</string>

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -824,6 +824,26 @@
     <string name="fg_class_extreme_greed">Extreme Greed</string>
     <string name="dashboard_purchase_amount_formula">%1$s %2$s (%3$s × %4$s) • %5$s</string>
 
+    <!-- Market Pulse Info Sheet -->
+    <string name="market_pulse_info_title">Market Pulse</string>
+    <string name="market_pulse_info_subtitle">Understanding market indicators</string>
+    <string name="market_pulse_info_overview">Market Pulse shows two key indicators that help you understand the current state of the crypto market at a glance.</string>
+    <string name="market_pulse_info_fg_title">Fear &amp; Greed Index</string>
+    <string name="market_pulse_info_fg_description">The Fear &amp; Greed Index measures overall crypto market sentiment on a scale from 0 (extreme fear) to 100 (extreme greed). It combines signals like volatility, volume, social media, and trends.</string>
+    <string name="market_pulse_info_fg_extreme_fear">Extreme Fear (0–19)</string>
+    <string name="market_pulse_info_fg_extreme_fear_desc">Investors are very worried — often a buying opportunity</string>
+    <string name="market_pulse_info_fg_fear">Fear (20–39)</string>
+    <string name="market_pulse_info_fg_fear_desc">Market is cautious — prices may be undervalued</string>
+    <string name="market_pulse_info_fg_neutral">Neutral (40–59)</string>
+    <string name="market_pulse_info_fg_neutral_desc">Balanced sentiment — no strong signal</string>
+    <string name="market_pulse_info_fg_greed">Greed (60–79)</string>
+    <string name="market_pulse_info_fg_greed_desc">Optimism is high — prices may be elevated</string>
+    <string name="market_pulse_info_fg_extreme_greed">Extreme Greed (80–100)</string>
+    <string name="market_pulse_info_fg_extreme_greed_desc">Euphoria — market may be overheated</string>
+    <string name="market_pulse_info_ath_title">ATH Distance</string>
+    <string name="market_pulse_info_ath_description">ATH Distance shows how far the current price is from its All-Time High. A distance of 0% means the price is at ATH; 50% means the price has dropped halfway from the peak.</string>
+    <string name="market_pulse_info_dca_tip">The Fear &amp; Greed and ATH-based DCA strategies use these indicators to automatically adjust your purchase amounts — buying more when the market is fearful or far from ATH, and less when it\'s greedy or near the peak.</string>
+
     <!-- Settings: Market Pulse -->
     <string name="settings_market_pulse_title">Market Pulse</string>
     <string name="settings_market_pulse_subtitle">Show market indicators on dashboard</string>


### PR DESCRIPTION
## Summary
- Add educational info bottom sheet explaining Fear & Greed Index and ATH Distance indicators
- Info icon in Market Pulse card header opens a scrollable `ModalBottomSheet` with color-coded F&G scale, ATH explanation, and DCA strategy tip
- EN + CS string resources (20 new strings each)

## Test plan
- [ ] Dashboard → Market Pulse → info icon visible next to title
- [ ] Tap info icon → sheet opens (card does NOT expand/collapse)
- [ ] Sheet: overview, F&G scale with 5 color-coded rows, ATH explanation, DCA tip card
- [ ] Scrollable on small screens, "Got it" dismisses
- [ ] Tap card area → still toggles expand/collapse
- [ ] Verify CS translations (switch device language)

🤖 Generated with [Claude Code](https://claude.com/claude-code)