### PR TITLE
Unify exchange selection components across all screens

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ReusableComponents.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/components/ReusableComponents.kt
@@ -14,10 +14,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -27,7 +34,9 @@ import com.accbot.dca.R
 import com.accbot.dca.domain.model.DcaStrategy
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.TransactionStatus
+import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.presentation.ui.theme.Error
+import com.accbot.dca.presentation.ui.theme.Warning
 import com.accbot.dca.presentation.ui.theme.accentColor
 import com.accbot.dca.presentation.ui.theme.successColor
 
@@ -385,6 +394,287 @@ fun StrategyOption(
                     selectedColor = accentCol
                 )
             )
+        }
+    }
+}
+
+/**
+ * Unified exchange tile used across all exchange selection screens.
+ *
+ * @param exchange The exchange to display
+ * @param onClick Callback when tile is clicked
+ * @param isSelected Green bg + border (AddPlan, Onboarding selection)
+ * @param isConnected Green avatar bg (Management connected section)
+ * @param subtitle Override subtitle; default shows crypto count
+ */
+@Composable
+fun ExchangeSelectionTile(
+    exchange: Exchange,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    isConnected: Boolean = false,
+    subtitle: String? = null
+) {
+    val successCol = successColor()
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected) {
+                successCol.copy(alpha = 0.15f)
+            } else {
+                MaterialTheme.colorScheme.surface
+            }
+        ),
+        border = if (isSelected) {
+            CardDefaults.outlinedCardBorder().copy(
+                brush = SolidColor(successCol)
+            )
+        } else null
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            ExchangeAvatar(
+                exchange = exchange,
+                size = 48.dp,
+                isConnected = isConnected || isSelected
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = exchange.displayName,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = if (isSelected) successCol else MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = subtitle
+                    ?: stringResource(R.string.add_exchange_cryptos, exchange.supportedCryptos.size),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isConnected) successCol else MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            if (!isConnected && !exchange.isStable) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.experimental_badge),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Warning,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+/**
+ * "Request Exchange" card — OutlinedCard with Add icon, used in all exchange grids.
+ */
+@Composable
+fun RequestExchangeTile(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        border = CardDefaults.outlinedCardBorder()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.add_exchange_request),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+/**
+ * Toggle card for showing/hiding experimental exchanges.
+ */
+@Composable
+fun ExperimentalExchangesToggle(
+    isEnabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val haptic = LocalHapticFeedback.current
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                onToggle(!isEnabled)
+            }
+            .semantics(mergeDescendants = true) { role = Role.Switch },
+        colors = CardDefaults.cardColors(
+            containerColor = if (isEnabled) Warning.copy(alpha = 0.1f) else MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Explore,
+                contentDescription = null,
+                tint = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_experimental_exchanges),
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = if (isEnabled) {
+                        stringResource(R.string.settings_experimental_exchanges_enabled)
+                    } else {
+                        stringResource(R.string.settings_experimental_exchanges_disabled)
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = isEnabled,
+                onCheckedChange = null,
+                modifier = Modifier.clearAndSetSemantics {},
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Warning,
+                    checkedTrackColor = Warning.copy(alpha = 0.5f)
+                )
+            )
+        }
+    }
+}
+
+/**
+ * Disclaimer dialog shown when enabling the experimental exchanges toggle.
+ */
+@Composable
+fun ExperimentalToggleDisclaimer(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.experimental_warning_title)) },
+        text = { Text(stringResource(R.string.experimental_warning_text)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.experimental_warning_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_back))
+            }
+        }
+    )
+}
+
+/**
+ * Disclaimer dialog shown when selecting an experimental (non-stable) exchange.
+ */
+@Composable
+fun ExperimentalExchangeDisclaimer(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.experimental_exchange_warning_title)) },
+        text = { Text(stringResource(R.string.experimental_exchange_warning_text)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.experimental_warning_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_back))
+            }
+        }
+    )
+}
+
+/**
+ * 2-column exchange selection grid using chunked(2) + Row.
+ * Safe inside scrollable parents (unlike LazyVerticalGrid).
+ * Used by Onboarding, AddPlan, and AddExchange flat-selection screens.
+ */
+@Composable
+fun ExchangeSelectionGrid(
+    exchanges: List<Exchange>,
+    onExchangeClick: (Exchange) -> Unit,
+    modifier: Modifier = Modifier,
+    selectedExchange: Exchange? = null,
+    onRequestExchangeClick: (() -> Unit)? = null
+) {
+    // Build list of items: exchanges + optional request card sentinel
+    val hasRequestCard = onRequestExchangeClick != null
+    val totalItems = exchanges.size + if (hasRequestCard) 1 else 0
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        // chunked(2) over indices
+        (0 until totalItems).chunked(2).forEach { rowIndices ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                rowIndices.forEach { index ->
+                    if (index < exchanges.size) {
+                        val exchange = exchanges[index]
+                        ExchangeSelectionTile(
+                            exchange = exchange,
+                            isSelected = selectedExchange == exchange,
+                            onClick = { onExchangeClick(exchange) },
+                            modifier = Modifier.weight(1f)
+                        )
+                    } else {
+                        // Request exchange card
+                        RequestExchangeTile(
+                            onClick = onRequestExchangeClick!!,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+                // Spacer for odd-count row
+                if (rowIndices.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
         }
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/AddPlanScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -18,10 +17,8 @@ import androidx.compose.runtime.*
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -30,7 +27,6 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
@@ -38,9 +34,11 @@ import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.DcaStrategy
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.isStable
-import com.accbot.dca.presentation.ui.theme.Warning
-import com.accbot.dca.presentation.components.ExchangeAvatar
 import com.accbot.dca.presentation.components.CredentialsInputCard
+import com.accbot.dca.presentation.components.ExchangeSelectionGrid
+import com.accbot.dca.presentation.components.ExperimentalExchangeDisclaimer
+import com.accbot.dca.presentation.components.ExperimentalExchangesToggle
+import com.accbot.dca.presentation.components.ExperimentalToggleDisclaimer
 import com.accbot.dca.presentation.components.MonthlyCostEstimateCard
 import com.accbot.dca.presentation.components.QrScannerButton
 import com.accbot.dca.presentation.components.SandboxCredentialsInfoCard
@@ -138,46 +136,24 @@ fun AddPlanScreen(
             // Experimental exchange disclaimer (selecting an experimental exchange)
             var experimentalExchangePending by remember { mutableStateOf<Exchange?>(null) }
             experimentalExchangePending?.let { exchange ->
-                AlertDialog(
-                    onDismissRequest = { experimentalExchangePending = null },
-                    title = { Text(stringResource(R.string.experimental_exchange_warning_title)) },
-                    text = { Text(stringResource(R.string.experimental_exchange_warning_text)) },
-                    confirmButton = {
-                        TextButton(onClick = {
-                            experimentalExchangePending = null
-                            viewModel.selectExchange(exchange)
-                        }) {
-                            Text(stringResource(R.string.experimental_warning_confirm))
-                        }
+                ExperimentalExchangeDisclaimer(
+                    onConfirm = {
+                        experimentalExchangePending = null
+                        viewModel.selectExchange(exchange)
                     },
-                    dismissButton = {
-                        TextButton(onClick = { experimentalExchangePending = null }) {
-                            Text(stringResource(R.string.common_back))
-                        }
-                    }
+                    onDismiss = { experimentalExchangePending = null }
                 )
             }
 
             // Experimental toggle disclaimer (enabling the toggle)
             var showExperimentalDisclaimer by remember { mutableStateOf(false) }
             if (showExperimentalDisclaimer) {
-                AlertDialog(
-                    onDismissRequest = { showExperimentalDisclaimer = false },
-                    title = { Text(stringResource(R.string.experimental_warning_title)) },
-                    text = { Text(stringResource(R.string.experimental_warning_text)) },
-                    confirmButton = {
-                        TextButton(onClick = {
-                            showExperimentalDisclaimer = false
-                            viewModel.setExperimentalExchangesEnabled(true)
-                        }) {
-                            Text(stringResource(R.string.experimental_warning_confirm))
-                        }
+                ExperimentalToggleDisclaimer(
+                    onConfirm = {
+                        showExperimentalDisclaimer = false
+                        viewModel.setExperimentalExchangesEnabled(true)
                     },
-                    dismissButton = {
-                        TextButton(onClick = { showExperimentalDisclaimer = false }) {
-                            Text(stringResource(R.string.common_back))
-                        }
-                    }
+                    onDismiss = { showExperimentalDisclaimer = false }
                 )
             }
 
@@ -186,48 +162,24 @@ fun AddPlanScreen(
             Column(
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                // Build items: exchanges + request card tile
-                data class ExchangeItem(val exchange: Exchange?, val isRequestCard: Boolean = false)
-                val items = uiState.availableExchanges.map { ExchangeItem(it) } + ExchangeItem(null, isRequestCard = true)
-
-                items.chunked(2).forEach { row ->
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        row.forEach { item ->
-                            if (item.isRequestCard) {
-                                RequestExchangeTile(
-                                    onClick = {
-                                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/Crynners/AccBot/issues"))
-                                        addPlanContext.startActivity(intent)
-                                    },
-                                    modifier = Modifier.weight(1f)
-                                )
-                            } else {
-                                ExchangeCard(
-                                    exchange = item.exchange!!,
-                                    isSelected = uiState.selectedExchange == item.exchange,
-                                    onClick = {
-                                        if (item.exchange.isStable) {
-                                            viewModel.selectExchange(item.exchange)
-                                        } else {
-                                            experimentalExchangePending = item.exchange
-                                        }
-                                    },
-                                    modifier = Modifier.weight(1f)
-                                )
-                            }
+                ExchangeSelectionGrid(
+                    exchanges = uiState.availableExchanges,
+                    onExchangeClick = { exchange ->
+                        if (exchange.isStable) {
+                            viewModel.selectExchange(exchange)
+                        } else {
+                            experimentalExchangePending = exchange
                         }
-                        // Fill remaining slot for incomplete row
-                        repeat(2 - row.size) {
-                            Spacer(modifier = Modifier.weight(1f))
-                        }
+                    },
+                    selectedExchange = uiState.selectedExchange,
+                    onRequestExchangeClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/Crynners/AccBot/issues"))
+                        addPlanContext.startActivity(intent)
                     }
-                }
+                )
 
                 // Experimental exchanges toggle
-                ExperimentalToggleRow(
+                ExperimentalExchangesToggle(
                     isEnabled = uiState.showExperimental,
                     onToggle = { enabled ->
                         if (enabled) {
@@ -578,163 +530,6 @@ private fun ExchangeInstructionsCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-        }
-    }
-}
-
-@Composable
-private fun ExchangeCard(
-    exchange: Exchange,
-    isSelected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val successCol = successColor()
-    Card(
-        modifier = modifier
-            .clickable(onClick = onClick),
-        colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) {
-                successCol.copy(alpha = 0.15f)
-            } else {
-                MaterialTheme.colorScheme.surface
-            }
-        ),
-        border = if (isSelected) {
-            CardDefaults.outlinedCardBorder().copy(
-                brush = androidx.compose.ui.graphics.SolidColor(successCol)
-            )
-        } else null
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            ExchangeAvatar(
-                exchange = exchange,
-                size = 48.dp,
-                isConnected = isSelected
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = exchange.displayName,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = if (isSelected) successCol else MaterialTheme.colorScheme.onSurface
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.add_exchange_cryptos, exchange.supportedCryptos.size),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            if (!exchange.isStable) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = stringResource(R.string.experimental_badge),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = Warning,
-                    fontWeight = FontWeight.SemiBold
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RequestExchangeTile(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    OutlinedCard(
-        modifier = modifier
-            .clickable(onClick = onClick),
-        border = CardDefaults.outlinedCardBorder()
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = Icons.Default.Add,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(R.string.add_exchange_request),
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-}
-
-@Composable
-private fun ExperimentalToggleRow(
-    isEnabled: Boolean,
-    onToggle: (Boolean) -> Unit
-) {
-    val haptic = LocalHapticFeedback.current
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable {
-                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                onToggle(!isEnabled)
-            }
-            .semantics(mergeDescendants = true) { role = Role.Switch },
-        colors = CardDefaults.cardColors(
-            containerColor = if (isEnabled) Warning.copy(alpha = 0.1f) else MaterialTheme.colorScheme.surface
-        )
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = Icons.Default.Explore,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.settings_experimental_exchanges),
-                    fontWeight = FontWeight.SemiBold,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurface
-                )
-                Text(
-                    text = if (isEnabled) {
-                        stringResource(R.string.settings_experimental_exchanges_enabled)
-                    } else {
-                        stringResource(R.string.settings_experimental_exchanges_disabled)
-                    },
-                    style = MaterialTheme.typography.labelSmall,
-                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            Switch(
-                checked = isEnabled,
-                onCheckedChange = null,
-                modifier = Modifier
-                    .clearAndSetSemantics {}
-                    .height(24.dp),
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = Warning,
-                    checkedTrackColor = Warning.copy(alpha = 0.5f)
-                )
-            )
         }
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/AddExchangeScreen.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -40,6 +39,9 @@ import com.accbot.dca.domain.model.supportsApiImport
 import com.accbot.dca.domain.usecase.ApiImportResultState
 import com.accbot.dca.presentation.components.AccBotTopAppBar
 import com.accbot.dca.presentation.components.CredentialsInputCard
+import com.accbot.dca.presentation.components.ExchangeSelectionTile
+import com.accbot.dca.presentation.components.ExperimentalExchangeDisclaimer
+import com.accbot.dca.presentation.components.RequestExchangeTile
 import com.accbot.dca.presentation.components.areCredentialsComplete
 import com.accbot.dca.presentation.ui.theme.Warning
 import com.accbot.dca.presentation.ui.theme.accentColor
@@ -166,23 +168,12 @@ private fun ExchangeSelectionStep(
 
     // Experimental exchange disclaimer dialog
     experimentalExchangePending?.let { exchange ->
-        AlertDialog(
-            onDismissRequest = { experimentalExchangePending = null },
-            title = { Text(stringResource(R.string.experimental_exchange_warning_title)) },
-            text = { Text(stringResource(R.string.experimental_exchange_warning_text)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    experimentalExchangePending = null
-                    onSelectExchange(exchange)
-                }) {
-                    Text(stringResource(R.string.experimental_warning_confirm))
-                }
+        ExperimentalExchangeDisclaimer(
+            onConfirm = {
+                experimentalExchangePending = null
+                onSelectExchange(exchange)
             },
-            dismissButton = {
-                TextButton(onClick = { experimentalExchangePending = null }) {
-                    Text(stringResource(R.string.common_back))
-                }
-            }
+            onDismiss = { experimentalExchangePending = null }
         )
     }
 
@@ -205,7 +196,7 @@ private fun ExchangeSelectionStep(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             items(availableExchanges, key = { it.name }) { exchange ->
-                ExchangeSelectionCard(
+                ExchangeSelectionTile(
                     exchange = exchange,
                     onClick = {
                         if (exchange.isStable) {
@@ -219,7 +210,7 @@ private fun ExchangeSelectionStep(
 
             // "Request Exchange" card
             item {
-                RequestExchangeCard(
+                RequestExchangeTile(
                     onClick = {
                         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/Crynners/AccBot/issues"))
                         context.startActivity(intent)
@@ -252,94 +243,6 @@ private fun ExchangeSelectionStep(
                     )
                 }
             }
-        }
-    }
-}
-
-@Composable
-internal fun ExchangeSelectionCard(
-    exchange: Exchange,
-    onClick: () -> Unit
-) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Image(
-                painter = painterResource(exchange.logoRes),
-                contentDescription = exchange.displayName,
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(RoundedCornerShape(12.dp)),
-                contentScale = ContentScale.Fit
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = exchange.displayName,
-                fontWeight = FontWeight.SemiBold
-            )
-
-            Text(
-                text = stringResource(R.string.add_exchange_cryptos, exchange.supportedCryptos.size),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            if (!exchange.isStable) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = stringResource(R.string.experimental_badge),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = Warning,
-                    fontWeight = FontWeight.SemiBold
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RequestExchangeCard(
-    onClick: () -> Unit
-) {
-    OutlinedCard(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-        border = CardDefaults.outlinedCardBorder()
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = Icons.Default.Add,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = stringResource(R.string.add_exchange_request),
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/exchanges/ExchangeManagementScreen.kt
@@ -2,7 +2,6 @@ package com.accbot.dca.presentation.screens.exchanges
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -18,16 +17,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.R
@@ -35,10 +26,11 @@ import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.presentation.components.AccBotTopAppBar
 import com.accbot.dca.presentation.components.EmptyState
-import com.accbot.dca.presentation.components.ExchangeAvatar
+import com.accbot.dca.presentation.components.ExchangeSelectionTile
+import com.accbot.dca.presentation.components.ExperimentalExchangesToggle
+import com.accbot.dca.presentation.components.ExperimentalToggleDisclaimer
+import com.accbot.dca.presentation.components.RequestExchangeTile
 import com.accbot.dca.presentation.components.SectionHeader
-import com.accbot.dca.presentation.ui.theme.Warning
-import com.accbot.dca.presentation.ui.theme.successColor
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,23 +44,12 @@ fun ExchangeManagementScreen(
     var showExperimentalDisclaimer by remember { mutableStateOf(false) }
 
     if (showExperimentalDisclaimer) {
-        AlertDialog(
-            onDismissRequest = { showExperimentalDisclaimer = false },
-            title = { Text(stringResource(R.string.experimental_warning_title)) },
-            text = { Text(stringResource(R.string.experimental_warning_text)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    showExperimentalDisclaimer = false
-                    viewModel.setExperimentalExchangesEnabled(true)
-                }) {
-                    Text(stringResource(R.string.experimental_warning_confirm))
-                }
+        ExperimentalToggleDisclaimer(
+            onConfirm = {
+                showExperimentalDisclaimer = false
+                viewModel.setExperimentalExchangesEnabled(true)
             },
-            dismissButton = {
-                TextButton(onClick = { showExperimentalDisclaimer = false }) {
-                    Text(stringResource(R.string.common_back))
-                }
-            }
+            onDismiss = { showExperimentalDisclaimer = false }
         )
     }
 
@@ -127,9 +108,10 @@ fun ExchangeManagementScreen(
                     }
 
                     items(uiState.connectedExchanges, key = { it.name }) { exchange ->
-                        ExchangeTile(
+                        ExchangeSelectionTile(
                             exchange = exchange,
                             isConnected = true,
+                            subtitle = stringResource(R.string.common_connected),
                             onClick = { onNavigateToExchangeDetail(exchange.name) }
                         )
                     }
@@ -146,9 +128,8 @@ fun ExchangeManagementScreen(
 
                 if (availableExchanges.isNotEmpty()) {
                     items(availableExchanges, key = { it.name }) { exchange ->
-                        ExchangeTile(
+                        ExchangeSelectionTile(
                             exchange = exchange,
-                            isConnected = false,
                             onClick = { onNavigateToAddExchange(exchange.name) }
                         )
                     }
@@ -183,159 +164,6 @@ fun ExchangeManagementScreen(
                     Spacer(modifier = Modifier.height(16.dp))
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun ExchangeTile(
-    exchange: Exchange,
-    isConnected: Boolean,
-    onClick: () -> Unit
-) {
-    val successCol = successColor()
-
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            ExchangeAvatar(
-                exchange = exchange,
-                size = 48.dp,
-                isConnected = isConnected
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = exchange.displayName,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = if (isConnected) {
-                    stringResource(R.string.common_connected)
-                } else {
-                    stringResource(R.string.add_exchange_cryptos, exchange.supportedCryptos.size)
-                },
-                style = MaterialTheme.typography.bodySmall,
-                color = if (isConnected) successCol else MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
-            )
-            if (!isConnected && !exchange.isStable) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = stringResource(R.string.experimental_badge),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = Warning,
-                    fontWeight = FontWeight.SemiBold,
-                    textAlign = TextAlign.Center
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RequestExchangeTile(
-    onClick: () -> Unit
-) {
-    OutlinedCard(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-        border = CardDefaults.outlinedCardBorder()
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = Icons.Default.Add,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(R.string.add_exchange_request),
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
-            )
-        }
-    }
-}
-
-@Composable
-private fun ExperimentalExchangesToggle(
-    isEnabled: Boolean,
-    onToggle: (Boolean) -> Unit
-) {
-    val haptic = LocalHapticFeedback.current
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 8.dp)
-            .clickable {
-                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                onToggle(!isEnabled)
-            }
-            .semantics(mergeDescendants = true) { role = Role.Switch },
-        colors = CardDefaults.cardColors(
-            containerColor = if (isEnabled) Warning.copy(alpha = 0.1f) else MaterialTheme.colorScheme.surface
-        )
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = Icons.Default.Explore,
-                contentDescription = null,
-                tint = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.settings_experimental_exchanges),
-                    fontWeight = FontWeight.SemiBold,
-                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurface
-                )
-                Text(
-                    text = if (isEnabled) {
-                        stringResource(R.string.settings_experimental_exchanges_enabled)
-                    } else {
-                        stringResource(R.string.settings_experimental_exchanges_disabled)
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (isEnabled) Warning else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            Switch(
-                checked = isEnabled,
-                onCheckedChange = null,
-                modifier = Modifier.clearAndSetSemantics {},
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = Warning,
-                    checkedTrackColor = Warning.copy(alpha = 0.5f)
-                )
-            )
         }
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/ExchangeSetupScreen.kt
@@ -1,21 +1,21 @@
 package com.accbot.dca.presentation.screens.onboarding
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.*
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -23,11 +23,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.accbot.dca.domain.model.Exchange
+import com.accbot.dca.domain.model.ExchangeInstructions
+import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.presentation.components.CredentialsInputCard
+import com.accbot.dca.presentation.components.ExchangeSelectionGrid
+import com.accbot.dca.presentation.components.ExperimentalExchangeDisclaimer
+import com.accbot.dca.presentation.components.ExperimentalExchangesToggle
+import com.accbot.dca.presentation.components.ExperimentalToggleDisclaimer
+import com.accbot.dca.presentation.components.SandboxCredentialsInfoCard
 import com.accbot.dca.presentation.components.SandboxModeIndicator
 import com.accbot.dca.R
 import com.accbot.dca.presentation.ui.theme.accentColor
-import com.accbot.dca.presentation.ui.theme.successColor
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,6 +65,32 @@ fun ExchangeSetupScreen(
             )
         }
     ) { paddingValues ->
+        val context = LocalContext.current
+
+        // Experimental exchange disclaimer (selecting an experimental exchange)
+        var experimentalExchangePending by remember { mutableStateOf<Exchange?>(null) }
+        experimentalExchangePending?.let { exchange ->
+            ExperimentalExchangeDisclaimer(
+                onConfirm = {
+                    experimentalExchangePending = null
+                    viewModel.selectExchange(exchange)
+                },
+                onDismiss = { experimentalExchangePending = null }
+            )
+        }
+
+        // Experimental toggle disclaimer (enabling the toggle)
+        var showExperimentalDisclaimer by remember { mutableStateOf(false) }
+        if (showExperimentalDisclaimer) {
+            ExperimentalToggleDisclaimer(
+                onConfirm = {
+                    showExperimentalDisclaimer = false
+                    viewModel.setExperimentalExchangesEnabled(true)
+                },
+                onDismiss = { showExperimentalDisclaimer = false }
+            )
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -103,34 +135,56 @@ fun ExchangeSetupScreen(
                 Spacer(modifier = Modifier.height(16.dp))
             }
 
-            // Exchange grid - using Column with chunked() to avoid nested scroll
-            Column(
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                uiState.availableExchanges.chunked(2).forEach { row ->
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        row.forEach { exchange ->
-                            ExchangeGridItem(
-                                exchange = exchange,
-                                isSelected = uiState.selectedExchange == exchange,
-                                onClick = { viewModel.selectExchange(exchange) },
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-                        // Spacer for odd count to maintain layout
-                        if (row.size == 1) {
-                            Spacer(modifier = Modifier.weight(1f))
-                        }
+            // Exchange selection grid with request card
+            ExchangeSelectionGrid(
+                exchanges = uiState.availableExchanges,
+                onExchangeClick = { exchange ->
+                    if (exchange.isStable) {
+                        viewModel.selectExchange(exchange)
+                    } else {
+                        experimentalExchangePending = exchange
+                    }
+                },
+                selectedExchange = uiState.selectedExchange,
+                onRequestExchangeClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/Crynners/AccBot/issues"))
+                    context.startActivity(intent)
+                }
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Experimental exchanges toggle
+            ExperimentalExchangesToggle(
+                isEnabled = uiState.showExperimental,
+                onToggle = { enabled ->
+                    if (enabled) {
+                        showExperimentalDisclaimer = true
+                    } else {
+                        viewModel.setExperimentalExchangesEnabled(false)
                     }
                 }
-            }
+            )
 
-            // Credentials input (only show when exchange is selected)
+            // Instructions + credentials (only show when exchange is selected)
             if (uiState.selectedExchange != null) {
                 Spacer(modifier = Modifier.height(24.dp))
+
+                // Exchange setup instructions card
+                if (uiState.selectedExchangeInstructions != null) {
+                    if (uiState.isSandboxMode) {
+                        SandboxCredentialsInfoCard(
+                            exchange = uiState.selectedExchange!!,
+                            instructions = uiState.selectedExchangeInstructions!!
+                        )
+                    } else {
+                        ExchangeInstructionsCard(
+                            exchange = uiState.selectedExchange!!,
+                            instructions = uiState.selectedExchangeInstructions!!
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
 
                 CredentialsInputCard(
                     exchange = uiState.selectedExchange!!,
@@ -186,49 +240,75 @@ fun ExchangeSetupScreen(
 }
 
 @Composable
-internal fun ExchangeGridItem(
+private fun ExchangeInstructionsCard(
     exchange: Exchange,
-    isSelected: Boolean,
-    onClick: () -> Unit,
+    instructions: ExchangeInstructions,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+    val resolvedUrl = instructions.urlRes?.let { stringResource(it) } ?: instructions.url
+    val accentCol = accentColor()
+
     Card(
-        modifier = modifier
-            .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) {
-                successColor().copy(alpha = 0.15f)
-            } else {
-                MaterialTheme.colorScheme.surface
-            }
+            containerColor = MaterialTheme.colorScheme.surface
         ),
-        border = if (isSelected) {
-            CardDefaults.outlinedCardBorder().copy(
-                brush = androidx.compose.ui.graphics.SolidColor(successColor())
-            )
-        } else null
+        modifier = modifier.fillMaxWidth()
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Image(
-                painter = painterResource(exchange.logoRes),
-                contentDescription = exchange.displayName,
-                modifier = Modifier.size(40.dp),
-                contentScale = ContentScale.Fit
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
             Text(
-                text = exchange.displayName,
-                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                style = MaterialTheme.typography.bodyMedium,
-                color = if (isSelected) successColor() else MaterialTheme.colorScheme.onSurface
+                stringResource(R.string.add_exchange_api_setup),
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.titleSmall
             )
+
+            instructions.steps.forEachIndexed { index, stepResId ->
+                Row {
+                    Text(
+                        "${index + 1}.",
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.width(24.dp)
+                    )
+                    Text(stringResource(stepResId), style = MaterialTheme.typography.bodySmall)
+                }
+            }
+
+            if (resolvedUrl.isNotBlank()) {
+                OutlinedButton(
+                    onClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(resolvedUrl))
+                        context.startActivity(intent)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = accentCol)
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.add_exchange_open_api_page, exchange.displayName))
+                }
+            }
+
+            Row(
+                verticalAlignment = Alignment.Top
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = accentCol,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.add_exchange_security_tip),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }

--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/OnboardingViewModel.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/screens/onboarding/OnboardingViewModel.kt
@@ -10,6 +10,9 @@ import com.accbot.dca.data.local.UserPreferences
 import com.accbot.dca.domain.model.DcaFrequency
 import com.accbot.dca.domain.model.Exchange
 import com.accbot.dca.domain.model.ExchangeFilter
+import com.accbot.dca.domain.model.ExchangeInstructions
+import com.accbot.dca.domain.model.ExchangeInstructionsProvider
+import com.accbot.dca.domain.model.isStable
 import com.accbot.dca.domain.usecase.CredentialValidationResult
 import com.accbot.dca.domain.usecase.ValidateAndSaveCredentialsUseCase
 import com.accbot.dca.exchange.MinOrderSizeRepository
@@ -27,9 +30,11 @@ data class OnboardingUiState(
     // Sandbox state (immutable after init)
     val isSandboxMode: Boolean = false,
     val availableExchanges: List<Exchange> = emptyList(),
+    val showExperimental: Boolean = false,
 
     // Exchange setup
     val selectedExchange: Exchange? = null,
+    val selectedExchangeInstructions: ExchangeInstructions? = null,
     val clientId: String = "",
     val apiKey: String = "",
     val apiSecret: String = "",
@@ -75,6 +80,7 @@ class OnboardingViewModel @Inject constructor(
     init {
         // Initialize sandbox state once - avoids repeated calls during recomposition
         val isSandbox = userPreferences.isSandboxMode()
+        val showExperimental = userPreferences.areExperimentalExchangesEnabled()
         // Detect already-configured exchange (e.g. credentials saved on ExchangeSetupScreen).
         // hiltViewModel() creates a separate instance per NavBackStackEntry, so FirstPlanScreen
         // needs to restore the selected exchange from persisted credentials.
@@ -82,7 +88,9 @@ class OnboardingViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 isSandboxMode = isSandbox,
-                availableExchanges = ExchangeFilter.getAvailableExchanges(isSandbox),
+                showExperimental = showExperimental,
+                availableExchanges = ExchangeFilter.getAvailableExchanges(isSandbox)
+                    .filter { exchange -> showExperimental || exchange.isStable },
                 selectedExchange = configured,
                 selectedCrypto = configured?.supportedCryptos?.firstOrNull() ?: "BTC",
                 selectedFiat = configured?.supportedFiats?.firstOrNull() ?: "EUR",
@@ -94,11 +102,26 @@ class OnboardingViewModel @Inject constructor(
         }
     }
 
+    fun setExperimentalExchangesEnabled(enabled: Boolean) {
+        userPreferences.setExperimentalExchangesEnabled(enabled)
+        val isSandbox = _uiState.value.isSandboxMode
+        _uiState.update {
+            it.copy(
+                showExperimental = enabled,
+                availableExchanges = ExchangeFilter.getAvailableExchanges(isSandbox)
+                    .filter { exchange -> enabled || exchange.isStable }
+            )
+        }
+    }
+
     // Exchange setup functions
     fun selectExchange(exchange: Exchange) {
+        val isSandbox = _uiState.value.isSandboxMode
+        val instructions = ExchangeInstructionsProvider.getInstructions(exchange, isSandbox)
         _uiState.update { state ->
             state.copy(
                 selectedExchange = exchange,
+                selectedExchangeInstructions = instructions,
                 selectedCrypto = exchange.supportedCryptos.firstOrNull() ?: "BTC",
                 selectedFiat = exchange.supportedFiats.firstOrNull() ?: "EUR",
                 clientId = "",

--- a/accbot-android/app/src/main/res/values-cs/strings.xml
+++ b/accbot-android/app/src/main/res/values-cs/strings.xml
@@ -370,7 +370,7 @@
     <string name="add_exchange_open_testnet">Otevřít %1$s Testnet</string>
     <string name="add_exchange_open_api_page">Otevřít %1$s API stránku</string>
     <string name="add_exchange_testnet_info">Testovací přihlašovací údaje jsou oddělené od vašeho skutečného účtu na burze. Testovací prostředky jsou poskytovány zdarma.</string>
-    <string name="add_exchange_security_tip">Bezpečnostní tip: Povolte pouze obchodní oprávnění. Nikdy nepovolujte oprávnění k výběru pro DCA roboty.</string>
+    <string name="add_exchange_security_tip">Bezpečnostní tip: Povolte pouze obchodní oprávnění. Oprávnění k výběru udělujte pouze pokud plánujete používat automatický výběr.</string>
     <string name="add_exchange_i_have_keys">Mám své API klíče</string>
     <string name="add_exchange_enter_credentials">Zadejte přihlašovací údaje pro %1$s API</string>
     <string name="add_exchange_connect">Připojit burzu</string>
@@ -477,7 +477,7 @@
     <string name="security_keystore_desc">Šifrovací klíče chráněny hardwarovým zabezpečením</string>
     <string name="security_direct_title">Přímá API volání</string>
     <string name="security_direct_desc">Komunikace probíhá přímo s burzami přes HTTPS</string>
-    <string name="security_tip">Tip: Vytvořte API klíče pouze s oprávněním k obchodování. Nikdy nepovolujte oprávnění k výběru.</string>
+    <string name="security_tip">Tip: Vytvořte API klíče pouze s oprávněním k obchodování. Oprávnění k výběru udělujte pouze pokud plánujete používat automatický výběr.</string>
     <string name="security_i_understand">Rozumím</string>
 
     <!-- Onboarding - Exchange Setup -->
@@ -624,7 +624,11 @@
     <string name="import_api_no_new">Žádné nové transakce k importu</string>
     <string name="import_api_offer_title">Importovat historii transakcí?</string>
     <string name="import_api_offer_text">Chcete importovat existující historii transakcí z %1$s? Můžete to udělat i později v detailu burzy.</string>
-    <string name="import_api_dialog_text">Import historie obchodů pro %1$d plánů.</string>
+    <plurals name="import_api_dialog_text">
+        <item quantity="one">Import historie obchodů pro %1$d plán.</item>
+        <item quantity="few">Import historie obchodů pro %1$d plány.</item>
+        <item quantity="other">Import historie obchodů pro %1$d plánů.</item>
+    </plurals>
     <string name="import_api_from_label">Od</string>
     <string name="import_api_all_history">Celá historie</string>
     <string name="import_api_start">Importovat</string>

--- a/accbot-android/app/src/main/res/values/strings.xml
+++ b/accbot-android/app/src/main/res/values/strings.xml
@@ -369,7 +369,7 @@
     <string name="add_exchange_open_testnet">Open %1$s Testnet</string>
     <string name="add_exchange_open_api_page">Open %1$s API Page</string>
     <string name="add_exchange_testnet_info">Testnet credentials are separate from your real exchange account. Test funds are provided for free.</string>
-    <string name="add_exchange_security_tip">Security tip: Only enable trading permissions. Never enable withdrawal permissions for DCA bots.</string>
+    <string name="add_exchange_security_tip">Security tip: Only enable trading permissions. Grant withdrawal permissions only if you plan to use auto-withdrawal.</string>
     <string name="add_exchange_i_have_keys">I have my API keys</string>
     <string name="add_exchange_enter_credentials">Enter your %1$s API credentials</string>
     <string name="add_exchange_connect">Connect Exchange</string>
@@ -476,7 +476,7 @@
     <string name="security_keystore_desc">Encryption keys protected by hardware security</string>
     <string name="security_direct_title">Direct API Calls</string>
     <string name="security_direct_desc">Communication goes directly to exchanges via HTTPS</string>
-    <string name="security_tip">Tip: Create API keys with only trading permissions. Never enable withdrawal permissions.</string>
+    <string name="security_tip">Tip: Create API keys with only trading permissions. Grant withdrawal permissions only if you plan to use auto-withdrawal.</string>
     <string name="security_i_understand">I Understand</string>
 
     <!-- Onboarding - Exchange Setup -->
@@ -644,7 +644,10 @@
     <string name="import_api_no_new">No new transactions to import</string>
     <string name="import_api_offer_title">Import Transaction History?</string>
     <string name="import_api_offer_text">Would you like to import your existing transaction history from %1$s? You can also do this later from the exchange detail screen.</string>
-    <string name="import_api_dialog_text">Import trade history for %1$d plans.</string>
+    <plurals name="import_api_dialog_text">
+        <item quantity="one">Import trade history for %1$d plan.</item>
+        <item quantity="other">Import trade history for %1$d plans.</item>
+    </plurals>
     <string name="import_api_from_label">From</string>
     <string name="import_api_all_history">All history</string>
     <string name="import_api_start">Import</string>


### PR DESCRIPTION
## Summary
- Extract 6 shared composables (`ExchangeSelectionTile`, `RequestExchangeTile`, `ExperimentalExchangesToggle`, `ExperimentalToggleDisclaimer`, `ExperimentalExchangeDisclaimer`, `ExchangeSelectionGrid`) into `ReusableComponents.kt`, replacing 4 separate duplicate implementations
- Onboarding `ExchangeSetupScreen` gains experimental toggle, request exchange card, experimental badges/disclaimers, and API setup instructions card — all previously missing
- Update security tip strings to clarify withdrawal permissions are acceptable when using auto-withdrawal

## Test plan
- [ ] Verify onboarding exchange screen shows experimental toggle, request card, badges, disclaimers, and API instructions
- [ ] Verify AddPlan exchange selection looks identical to before
- [ ] Verify Exchange Management screen looks identical to before
- [ ] Verify Add Exchange flow looks identical to before
- [ ] Test experimental toggle + both disclaimers on all 4 screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)