### PR TITLE
Release v2.5.2 — Chart Fix & Branding

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/changelog/ChangelogData.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/changelog/ChangelogData.kt
@@ -6,6 +6,26 @@ package com.accbot.dca.presentation.changelog
 object ChangelogData {
     val entries: List<ChangelogEntry> = listOf(
         ChangelogEntry(
+            versionCode = 25200,
+            version = "2.5.2",
+            titles = mapOf(
+                "cs" to "Oprava grafu a branding",
+                "en" to "Chart Fix & Branding",
+            ),
+            features = mapOf(
+                "cs" to listOf(
+                    "Oprava pádu grafu portfolia s jedinou transakcí",
+                    "Použití ceny transakce jako zálohy, když chybí denní cenová data",
+                    "#OwnYourDCA branding v Nastavení",
+                ),
+                "en" to listOf(
+                    "Fix portfolio chart crash with a single transaction",
+                    "Use transaction execution price as fallback when daily price data is missing",
+                    "#OwnYourDCA branding in Settings",
+                ),
+            )
+        ),
+        ChangelogEntry(
             versionCode = 25100,
             version = "2.5.1",
             titles = mapOf(

--- a/accbot-android/gradle.properties
+++ b/accbot-android/gradle.properties
@@ -9,7 +9,7 @@ android.nonTransitiveRClass=true
 # App versioning (semver)
 VERSION_MAJOR=2
 VERSION_MINOR=5
-VERSION_PATCH=1
+VERSION_PATCH=2
 
 # Screenshot testing
 android.experimental.enableScreenshotTest=true

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,25 @@
 [
   {
+    "versionCode": 25200,
+    "version": "2.5.2",
+    "title": {
+      "en": "Chart Fix & Branding",
+      "cs": "Oprava grafu a branding"
+    },
+    "features": {
+      "en": [
+        "Fix portfolio chart crash with a single transaction",
+        "Use transaction execution price as fallback when daily price data is missing",
+        "#OwnYourDCA branding in Settings"
+      ],
+      "cs": [
+        "Oprava pádu grafu portfolia s jedinou transakcí",
+        "Použití ceny transakce jako zálohy, když chybí denní cenová data",
+        "#OwnYourDCA branding v Nastavení"
+      ]
+    }
+  },
+  {
     "versionCode": 25100,
     "version": "2.5.1",
     "title": {


### PR DESCRIPTION
## Summary
- Bump version to **v2.5.2**
- Add release notes to `changelog.json` and `ChangelogData.kt`

### What's New
- Fix portfolio chart crash with a single transaction (fallback to execution price when daily price data is missing)
- `#OwnYourDCA` branding in Settings

## Test plan
- [ ] Verify version shows 2.5.2 in Settings
- [ ] Test portfolio chart with 1 transaction — should show "insufficient data" message instead of crash
- [ ] Test portfolio chart with 2+ transactions — should render normally
- [ ] Verify "What's New" shows v2.5.2 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)