### PR TITLE
Release v2.6.1 — DRY refactor & Binance USDC

### DIFF
--- a/accbot-android/app/src/main/java/com/accbot/dca/presentation/changelog/ChangelogData.kt
+++ b/accbot-android/app/src/main/java/com/accbot/dca/presentation/changelog/ChangelogData.kt
@@ -36,6 +36,36 @@ object ChangelogData {
             )
         ),
         ChangelogEntry(
+            versionCode = 26000,
+            version = "2.6.0",
+            titles = mapOf(
+                "cs" to "Výkon a chytré obnovování",
+                "en" to "Performance & Smart Refresh",
+            ),
+            features = mapOf(
+                "cs" to listOf(
+                    "Chytré obnovování — Dashboard a Portfolio načítají data jen když jsou zastaralá (5 min)",
+                    "SQL filtrování v historii transakcí — rychlejší s velkým množstvím dat",
+                    "Debounce vyhledávání (300ms) — plynulejší psaní v historii",
+                    "Cachování Fear & Greed indexu (1h TTL) — méně API volání",
+                    "Real-time cena v grafu portfolia — dnešní bod se aktualizuje okamžitě",
+                    "Optimalizované pořadí načítání tržních dat — warm-up cache před dotazy na ceny",
+                    "Nový DB index na transakcích pro rychlejší filtrované dotazy",
+                    "Úklid repositáře — archivace neaktivních .NET, Docker a legacy projektů",
+                ),
+                "en" to listOf(
+                    "Smart refresh — Dashboard and Portfolio only reload when data is stale (5 min)",
+                    "SQL-level filtering in transaction history — faster with large datasets",
+                    "Search debounce (300ms) — smoother typing in history search",
+                    "Fear & Greed index caching (1h TTL) — fewer API calls",
+                    "Real-time price in portfolio chart — today's data point updates immediately",
+                    "Market data fetch order optimized — cache warm-up before price lookups",
+                    "New DB index on transactions for faster filtered queries",
+                    "Repository cleanup — archived inactive .NET, Docker and legacy projects",
+                ),
+            )
+        ),
+        ChangelogEntry(
             versionCode = 25200,
             version = "2.5.2",
             titles = mapOf(

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,35 @@
 [
   {
+    "versionCode": 26100,
+    "version": "2.6.1",
+    "title": {
+      "en": "DRY Refactor & Binance USDC",
+      "cs": "DRY refaktoring a Binance USDC"
+    },
+    "features": {
+      "en": [
+        "Shared CredentialFormDelegate — less duplicate code across 4 ViewModels",
+        "Shared API import result dialog across 3 screens",
+        "Unified AccBotTopAppBar across 11 screens",
+        "Binance: switch from USDT to USDC, min order lowered to 5",
+        "Quick amounts: 5, 10, 25, 50, 100 (was 25–500)",
+        "Default DCA plan amount set to exchange minimum",
+        "Fix min order size display — strip trailing zeros",
+        "Extract KuCoin signed-request helper and ROI calculation"
+      ],
+      "cs": [
+        "Sdílený CredentialFormDelegate — méně duplicitního kódu napříč 4 ViewModely",
+        "Sdílený dialog výsledku API importu na 3 obrazovkách",
+        "Jednotný AccBotTopAppBar na 11 obrazovkách",
+        "Binance: přechod z USDT na USDC, minimální objednávka snížena na 5",
+        "Rychlé částky: 5, 10, 25, 50, 100 (dříve 25–500)",
+        "Výchozí částka DCA plánu nastavena na minimum burzy",
+        "Oprava zobrazení minimální částky — bez zbytečných nul",
+        "Extrakce KuCoin signed-request helperu a ROI výpočtu"
+      ]
+    }
+  },
+  {
     "versionCode": 26000,
     "version": "2.6.0",
     "title": {


### PR DESCRIPTION
## Summary
- Add v2.6.1 entry to `changelog.json` (was missing)
- Add v2.6.0 entry to `ChangelogData.kt` (was missing — regenerated from `changelog.json`)
- Both `changelog.json` and `ChangelogData.kt` now contain release notes for v2.6.0 and v2.6.1, so the in-app "What's New" screen will show both versions

## Release notes (v2.6.1)
- Shared CredentialFormDelegate — less duplicate code across 4 ViewModels
- Shared API import result dialog across 3 screens
- Unified AccBotTopAppBar across 11 screens
- Binance: switch from USDT to USDC, min order lowered to 5
- Quick amounts: 5, 10, 25, 50, 100 (was 25–500)
- Default DCA plan amount set to exchange minimum
- Fix min order size display — strip trailing zeros
- Extract KuCoin signed-request helper and ROI calculation

## CI flow
Merge → `auto-release-tag` creates `v2.6.1` tag → `android-release` builds signed AAB/APK → GitHub Release with artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)